### PR TITLE
Feature: Implement audio recording pipeline (mic + speaker)

### DIFF
--- a/capture-overlay/src/CaptureOverlay.cpp
+++ b/capture-overlay/src/CaptureOverlay.cpp
@@ -14,7 +14,9 @@
 void CaptureOverlay::onMicLevelUpdated(double) { /* unused — using polling */ }
 // ── Constructor ───────────────────────────────────────────────────────────────
 
-CaptureOverlay::CaptureOverlay(const QPixmap& background, QWidget* parent, bool timerCaptureEnabled)
+CaptureOverlay::CaptureOverlay(const QPixmap& background, QWidget* parent,
+                               bool timerCaptureEnabled,
+                               bool initialMic, bool initialSpeaker)
     : QWidget(parent)
     , m_background(background)
     , m_hasSelection(false)
@@ -81,8 +83,8 @@ CaptureOverlay::CaptureOverlay(const QPixmap& background, QWidget* parent, bool 
     , m_gifQuality(0.75)
     , m_optimizeGif(true)
     , m_gifSizeIdx(0) // 800 x auto (default)
-    , m_recMic(false)
-    , m_recSpeaker(false)
+    , m_recMic(initialMic)
+    , m_recSpeaker(initialSpeaker)
     , m_recWebcam(false)
     , m_micLevel(0.0)
     , m_speakerLevel(0.0)
@@ -191,4 +193,3 @@ CaptureOverlay::CaptureOverlay(const QPixmap& background, QWidget* parent, bool 
     });
     m_micTimer->start();
 }
-

--- a/capture-overlay/src/CaptureOverlay.h
+++ b/capture-overlay/src/CaptureOverlay.h
@@ -49,7 +49,9 @@ public:
 
     explicit CaptureOverlay(const QPixmap& background = QPixmap(),
                              QWidget* parent = nullptr,
-                             bool timerCaptureEnabled = false);
+                             bool timerCaptureEnabled = false,
+                             bool initialMic = false,
+                             bool initialSpeaker = false);
 
     /// Returns the selected rectangle in screen (logical pixel) coordinates.
     /// Only valid when QApplication exits with code 0.

--- a/capture-overlay/src/main.cpp
+++ b/capture-overlay/src/main.cpp
@@ -150,6 +150,8 @@ int main(int argc, char* argv[])
     bool windowCaptureMode = false;
     QString backgroundPath;
     QRect restoreSel;
+    bool initialMic = false;
+    bool initialSpeaker = false;
 
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--background") == 0 && i + 1 < argc) {
@@ -169,6 +171,10 @@ int main(int argc, char* argv[])
                 restoreSel = QRect(parts[0].toInt(), parts[1].toInt(),
                                    parts[2].toInt(), parts[3].toInt());
             }
+        } else if (std::strcmp(argv[i], "--rec-mic") == 0) {
+            initialMic = true;
+        } else if (std::strcmp(argv[i], "--rec-speaker") == 0) {
+            initialSpeaker = true;
         }
     }
 
@@ -291,7 +297,7 @@ int main(int argc, char* argv[])
         }
     }
 
-    CaptureOverlay overlay(background, nullptr, areaInitMode);
+    CaptureOverlay overlay(background, nullptr, areaInitMode, initialMic, initialSpeaker);
     if (!restoreSel.isNull() && restoreSel.isValid()) {
         overlay.setInitialSelection(restoreSel);
     }

--- a/src/capture_overlay.rs
+++ b/src/capture_overlay.rs
@@ -381,6 +381,13 @@ pub fn capture_area_file_via_cpp() -> Result<AreaCapturePathResult, SelectionErr
         }
     }
 
+    if config.rec_mic {
+        extra_args.push("--rec-mic".into());
+    }
+    if config.rec_speaker {
+        extra_args.push("--rec-speaker".into());
+    }
+
     let arg_refs: Vec<&str> = extra_args.iter().map(|s| s.as_str()).collect();
     eprintln!(
         "[capture_overlay] capture_area_via_cpp: launching {:?}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,8 @@ pub struct AppConfig {
     pub rec_video_fps: u8,
     pub rec_video_mono: bool,
     pub rec_video_open_editor: bool,
+    pub rec_mic: bool,
+    pub rec_speaker: bool,
 }
 
 impl Default for AppConfig {
@@ -82,6 +84,8 @@ impl Default for AppConfig {
             rec_video_fps: 1,     // 1 = 30fps
             rec_video_mono: false,
             rec_video_open_editor: false,
+            rec_mic: false,
+            rec_speaker: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1015,6 +1015,8 @@ fn run_capture(args: &[String]) {
                 cfg.rec_remember_selection = request.remember_selection;
                 cfg.rec_dim_screen = request.dim_screen;
                 cfg.rec_countdown = request.countdown;
+                cfg.rec_mic = request.mic;
+                cfg.rec_speaker = request.speaker;
 
                 // Update config from overlay settings (Video tab)
                 cfg.rec_video_max_res = request.video_max_res;
@@ -1076,9 +1078,9 @@ fn run_capture(args: &[String]) {
 
                 // Map Video tab settings
                 let max_resolution = match request.video_max_res {
-                    0 => None,                      // Original
-                    1 => Some((1920, 1080)),        // 1080p
-                    2 => Some((1280, 720)),         // 720p
+                    0 => None,               // Original
+                    1 => Some((1920, 1080)), // 1080p
+                    2 => Some((1280, 720)),  // 720p
                     _ => None,
                 };
 
@@ -1102,6 +1104,10 @@ fn run_capture(args: &[String]) {
                     max_resolution,
                     fps,
                     mono_audio: request.record_mono,
+                    mic_enabled: request.mic,
+                    speaker_enabled: request.speaker,
+                    mic_source: None,
+                    speaker_source: None,
                 };
 
                 eprintln!("Starting recording to {:?}...", output_path);

--- a/src/recording/mod.rs
+++ b/src/recording/mod.rs
@@ -56,6 +56,10 @@ pub struct RecordingConfig {
     pub max_resolution: Option<(u32, u32)>,
     pub fps: u32,
     pub mono_audio: bool,
+    pub mic_enabled: bool,
+    pub speaker_enabled: bool,
+    pub mic_source: Option<String>,
+    pub speaker_source: Option<String>,
 }
 
 impl Default for RecordingConfig {
@@ -73,6 +77,10 @@ impl Default for RecordingConfig {
             max_resolution: None,
             fps: 30,
             mono_audio: false,
+            mic_enabled: false,
+            speaker_enabled: false,
+            mic_source: None,
+            speaker_source: None,
         }
     }
 }
@@ -414,6 +422,41 @@ fn select_encoder(
     Err(RecordError::NoEncoderFound)
 }
 
+fn get_pulse_default_source() -> String {
+    std::process::Command::new("pactl")
+        .arg("get-default-source")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "default".to_string())
+}
+
+fn get_pulse_speaker_monitor() -> String {
+    std::process::Command::new("pactl")
+        .arg("get-default-sink")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| format!("{}.monitor", s.trim()))
+        .filter(|s| s != ".monitor")
+        .unwrap_or_else(|| "default.monitor".to_string())
+}
+
+fn select_audio_encoder(muxer: &str) -> Option<&'static str> {
+    let candidates: &[&str] = match muxer {
+        "webmmux" => &["opusenc", "vorbisenc"],
+        "mp4mux" => &["fdkaacenc", "avenc_aac", "lamemp3enc"],
+        "oggmux" => &["vorbisenc"],
+        _ => &[],
+    };
+    candidates
+        .iter()
+        .find(|&&enc| gst::ElementFactory::find(enc).is_some())
+        .copied()
+}
+
 async fn build_pipeline(
     config: &RecordingConfig,
     profile: &EncoderProfile,
@@ -429,18 +472,17 @@ async fn build_pipeline(
     };
 
     // HiDPI: downscale to logical resolution (2x)
-    let hidpi_filter = if config.hidpi {
-        " ! videoscale"
-    } else {
-        ""
-    };
+    let hidpi_filter = if config.hidpi { " ! videoscale" } else { "" };
 
     // Max resolution: downscale if needed
     let resolution_filter = if let Some((max_w, max_h)) = config.max_resolution {
         if let (Some(w), Some(h)) = (config.width, config.height) {
             if w > max_w || h > max_h {
                 // Only downscale, never upscale
-                format!(" ! videoscale ! video/x-raw,width={},height={}", max_w, max_h)
+                format!(
+                    " ! videoscale ! video/x-raw,width={},height={}",
+                    max_w, max_h
+                )
             } else {
                 String::new()
             }
@@ -451,30 +493,93 @@ async fn build_pipeline(
         String::new()
     };
 
-    // TODO: Audio pipeline support
-    // When audio is implemented, the pipeline should include audio sources:
-    //
-    // Video: {video_source} ! videoconvert ! videorate ! ... -> muxer
-    // Audio: pulsesrc(speaker) ! audioconvert ! audioresample
-    //        pulsesrc(mic) ! audioconvert ! audioresample
-    //        -> audiomixer -> encoder -> muxer
-    //
-    // Mono audio (config.mono_audio):
-    //   Add caps filter after audioconvert to force mono output:
-    //   let mono_filter = if config.mono_audio {
-    //       " ! audio/x-raw,channels=1"
-    //   } else {
-    //       ""
-    //   };
-    //   Example: pulsesrc ! audioconvert{} ! audioresample ! ...
-    //
-    // The muxer (mp4mux/webmmux) will then combine video and audio streams.
+    let want_audio = config.mic_enabled || config.speaker_enabled;
 
-    Ok(format!(
-        "{} ! videoconvert{}{} ! videorate ! video/x-raw,framerate={}/1 ! queue ! {} {} ! {} ! filesink location=\"{}\"",
-        video_source, hidpi_filter, resolution_filter, config.fps,
-        profile.encoder, profile.props, profile.muxer, output_str
-    ))
+    let audio_encoder = if want_audio {
+        if gst::ElementFactory::find("pulsesrc").is_none() {
+            eprintln!(
+                "[recording] pulsesrc not found (gst-plugins-good missing?); recording without audio."
+            );
+            None
+        } else {
+            let enc = select_audio_encoder(profile.muxer);
+            if enc.is_none() {
+                eprintln!(
+                    "[recording] No audio encoder found for muxer {}; recording without audio.",
+                    profile.muxer
+                );
+            }
+            enc
+        }
+    } else {
+        None
+    };
+
+    let mono_caps = if config.mono_audio {
+        " ! audio/x-raw,channels=1"
+    } else {
+        ""
+    };
+
+    let mic_dev = config
+        .mic_source
+        .clone()
+        .unwrap_or_else(get_pulse_default_source);
+    let spk_dev = config
+        .speaker_source
+        .clone()
+        .unwrap_or_else(get_pulse_speaker_monitor);
+
+    if let Some(aenc) = audio_encoder {
+        let muxer_named = format!("{} name=mux", profile.muxer);
+
+        let video_leg =
+            format!(
+            "{} ! videoconvert{}{} ! videorate ! video/x-raw,framerate={}/1 ! queue ! {} {} ! mux.",
+            video_source, hidpi_filter, resolution_filter, config.fps,
+            profile.encoder, profile.props
+        );
+
+        let filesink_leg = format!("{} ! filesink location=\"{}\"", muxer_named, output_str);
+
+        let audio_legs = if config.mic_enabled && config.speaker_enabled {
+            vec![
+                format!("audiomixer name=amix ! {} ! mux.", aenc),
+                format!(
+                    "pulsesrc device=\"{}\" ! audioconvert ! audioresample{} ! queue ! amix.",
+                    mic_dev, mono_caps
+                ),
+                format!(
+                    "pulsesrc device=\"{}\" ! audioconvert ! audioresample{} ! queue ! amix.",
+                    spk_dev, mono_caps
+                ),
+            ]
+        } else {
+            let dev = if config.mic_enabled {
+                &mic_dev
+            } else {
+                &spk_dev
+            };
+            vec![format!(
+                "pulsesrc device=\"{}\" ! audioconvert ! audioresample{} ! queue ! {} ! mux.",
+                dev, mono_caps, aenc
+            )]
+        };
+
+        let full = std::iter::once(video_leg)
+            .chain(std::iter::once(filesink_leg))
+            .chain(audio_legs)
+            .collect::<Vec<_>>()
+            .join("  ");
+
+        Ok(full)
+    } else {
+        Ok(format!(
+            "{} ! videoconvert{}{} ! videorate ! video/x-raw,framerate={}/1 ! queue ! {} {} ! {} ! filesink location=\"{}\"",
+            video_source, hidpi_filter, resolution_filter, config.fps,
+            profile.encoder, profile.props, profile.muxer, output_str
+        ))
+    }
 }
 
 async fn get_wayland_source(cursor: bool) -> RecordResult<String> {
@@ -638,18 +743,17 @@ async fn record_gif_rust_with_optional_stop(
     };
 
     // HiDPI: downscale to logical resolution (2x)
-    let hidpi_filter = if config.hidpi {
-        " ! videoscale"
-    } else {
-        ""
-    };
+    let hidpi_filter = if config.hidpi { " ! videoscale" } else { "" };
 
     // Max resolution: downscale if needed
     let resolution_filter = if let Some((max_w, max_h)) = config.max_resolution {
         if let (Some(w), Some(h)) = (config.width, config.height) {
             if w > max_w || h > max_h {
                 // Only downscale, never upscale
-                format!(" ! videoscale ! video/x-raw,width={},height={}", max_w, max_h)
+                format!(
+                    " ! videoscale ! video/x-raw,width={},height={}",
+                    max_w, max_h
+                )
             } else {
                 String::new()
             }


### PR DESCRIPTION
This PR wires the end-to-end audio recording pipeline, enabling microphone and speaker (system audio) capture in video recordings via GStreamer `pulsesrc`.

### Recording Pipeline
- **`src/recording/mod.rs`**: Added `mic_enabled`, `speaker_enabled`, `mic_source`, and `speaker_source` fields to `RecordingConfig`.
- Implemented PulseAudio device discovery helpers (`get_pulse_default_source`, `get_pulse_speaker_monitor`) to auto-detect input/output devices via `pactl`.
- Implemented muxer-aware audio encoder selection (`select_audio_encoder`) supporting Opus/Vorbis (WebM) and AAC/MP3 (MP4).
- Replaced the TODO in `build_pipeline` with full audio GStreamer logic:
  - Constructs audio legs using `pulsesrc` -> `audioconvert` -> `audioresample`.
  - Mixes mic and speaker via `audiomixer` when both are enabled.
  - Applies mono channel caps (`audio/x-raw,channels=1`) if configured.
  - Gracefully falls back to video-only if `pulsesrc` or encoders are missing.

### Configuration & State Wiring
- **`src/config.rs`**: Added `rec_mic` and `rec_speaker` to `AppConfig` to persist audio toggle preferences.
- **`src/main.rs`**: Wired `request.mic` and `request.speaker` to `RecordingConfig` and updated/saved the config state during recording requests.
- **`src/capture_overlay.rs`**: Modified `capture_area_file_via_cpp` to pass `--rec-mic` and `--rec-speaker` flags to the overlay binary based on saved config.

### C++ Overlay Updates
- **`capture-overlay/src/main.cpp`**: Added CLI argument parsing for `--rec-mic` and `--rec-speaker` and passed initial state to `CaptureOverlay` constructor.
- **`capture-overlay/src/CaptureOverlay.h`** & **`.cpp`**: Updated constructor signature and member initialization to use the provided initial mic/speaker state instead of hardcoding `false`.

<a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/pull/8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/task/f1bbe57a-d40d-4b09-b0b5-a9cc48e5a2b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-2&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-2"><img alt="APE-2 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-2"></picture></a>