### PR TITLE
feat: implement GIF tab settings pipeline and fix slider drag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Cargo.lock
 capture-overlay/build/
 capture-overlay/dist/
 capture-overlay/out/
+.tmp-capture-overlay-build/
 
 # Editor
 .idea/

--- a/capture-overlay/src/CaptureOverlay.cpp
+++ b/capture-overlay/src/CaptureOverlay.cpp
@@ -66,6 +66,8 @@ CaptureOverlay::CaptureOverlay(const QPixmap& background, QWidget* parent,
     , m_clickAnimate(true)
     , m_sliderDragging(false)
     , m_keySliderDragging(false)
+    , m_gifFpsDragging(false)
+    , m_gifQualityDragging(false)
     , m_clickAnimTimer(nullptr)
     , m_clickAnimPhase(0.0)
     , m_keystrokeOptionsOpen(false)

--- a/capture-overlay/src/CaptureOverlay.h
+++ b/capture-overlay/src/CaptureOverlay.h
@@ -86,6 +86,18 @@ public:
     bool recordMono() const { return m_recordMono; }
     bool recordOpenEditor() const { return m_openEditor; }
 
+    // GIF tab settings — accessors
+    int recordGifFps() const { return m_gifFps; }
+    double recordGifQuality() const { return m_gifQuality; }
+    int recordGifSizeIdx() const { return m_gifSizeIdx; }
+    bool recordOptimizeGif() const { return m_optimizeGif; }
+
+    // GIF tab settings — setters for initial config load
+    void setInitialGifFps(int v) { m_gifFps = v; }
+    void setInitialGifQuality(double v) { m_gifQuality = v; }
+    void setInitialGifSizeIdx(int v) { m_gifSizeIdx = v; }
+    void setInitialGifOptimize(bool v) { m_optimizeGif = v; }
+
 protected:
     void paintEvent(QPaintEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
@@ -271,6 +283,10 @@ private:
     QRectF m_sliderTrackRect;  // cached click slider track rect for drag calc
     bool   m_keySliderDragging; // true while dragging keystroke size slider
     QRectF m_keySliderTrackRect; // cached keystroke slider track rect
+    bool   m_gifFpsDragging;       // true while dragging GIF FPS slider
+    bool   m_gifQualityDragging;   // true while dragging GIF quality slider
+    QRectF m_gifFpsTrackRect;      // cached GIF FPS slider track rect for drag calc
+    QRectF m_gifQualityTrackRect;  // cached GIF quality slider track rect for drag calc
     QTimer* m_clickAnimTimer;  // timer for preview animation ticks
     double m_clickAnimPhase;   // 0.0 to 1.0 cycling phase for animation
 

--- a/capture-overlay/src/CaptureOverlay_Drawing.cpp
+++ b/capture-overlay/src/CaptureOverlay_Drawing.cpp
@@ -1231,6 +1231,7 @@ void CaptureOverlay::drawSettingsMenu(QPainter& p, double panelX, double startY)
         double sliderX = valueX + 55;
         double sliderW = 220.0; // Fixed slider width for GIF FPS
         QRectF sliderTrack(sliderX, currY + (30 - 4) / 2.0, sliderW, 4);
+        m_gifFpsTrackRect = QRectF(sliderX, currY, sliderW, 30);
         p.setPen(Qt::NoPen);
         p.setBrush(QColor(255, 255, 255, 30));
         p.drawRoundedRect(sliderTrack, 2, 2);
@@ -1253,6 +1254,7 @@ void CaptureOverlay::drawSettingsMenu(QPainter& p, double panelX, double startY)
         drawLabel("GIF quality:", currY);
         double qSliderW = 160.0;
         QRectF qSliderTrack(valueX, currY + (30 - 4) / 2.0, qSliderW, 4);
+        m_gifQualityTrackRect = QRectF(valueX, currY, qSliderW, 30);
         p.setPen(Qt::NoPen);
         p.setBrush(QColor(255, 255, 255, 30));
         p.drawRoundedRect(qSliderTrack, 2, 2);

--- a/capture-overlay/src/CaptureOverlay_Events.cpp
+++ b/capture-overlay/src/CaptureOverlay_Events.cpp
@@ -261,11 +261,13 @@ void CaptureOverlay::mousePressEvent(QMouseEvent* event)
                         case 3: { // FPS Slider
                             double relX = pos.x() - m_settingsClickableRects[i].x();
                             m_gifFps = 5 + (int)(55.0 * std::max(0.0, std::min(1.0, relX / m_settingsClickableRects[i].width())));
+                            m_gifFpsDragging = true;
                             break;
                         }
                         case 4: { // Quality Slider
                             double relX = pos.x() - m_settingsClickableRects[i].x();
                             m_gifQuality = std::max(0.0, std::min(1.0, relX / m_settingsClickableRects[i].width()));
+                            m_gifQualityDragging = true;
                             break;
                         }
                         case 5: m_optimizeGif = !m_optimizeGif; break;
@@ -563,6 +565,18 @@ void CaptureOverlay::mouseMoveEvent(QMouseEvent* event)
         update();
         return;
     }
+    if (m_gifFpsDragging) {
+        double relX = pos.x() - m_gifFpsTrackRect.x();
+        m_gifFps = 5 + (int)(55.0 * std::max(0.0, std::min(1.0, relX / m_gifFpsTrackRect.width())));
+        update();
+        return;
+    }
+    if (m_gifQualityDragging) {
+        double relX = pos.x() - m_gifQualityTrackRect.x();
+        m_gifQuality = std::max(0.0, std::min(1.0, relX / m_gifQualityTrackRect.width()));
+        update();
+        return;
+    }
 
     // ── Global Dropdown Hover ───────────────────────────────────────────────
     if (m_dropdownOpen != -1) {
@@ -731,6 +745,12 @@ void CaptureOverlay::mouseReleaseEvent(QMouseEvent* event)
     if (m_keySliderDragging) {
         m_keySliderDragging = false;
         update();
+    }
+    if (m_gifFpsDragging) {
+        m_gifFpsDragging = false;
+    }
+    if (m_gifQualityDragging) {
+        m_gifQualityDragging = false;
     }
 
     // Reset recording panel hover state
@@ -963,4 +983,3 @@ void CaptureOverlay::keyPressEvent(QKeyEvent* event)
     default: QWidget::keyPressEvent(event);
     }
 }
-

--- a/capture-overlay/src/main.cpp
+++ b/capture-overlay/src/main.cpp
@@ -97,7 +97,8 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                          bool displayRecTime, bool hidpi, bool doNotDisturb,
                          bool showCursor, bool rememberSelection,
                          bool dimScreen, bool countdown,
-                         int videoMaxRes, int videoFps, bool recordMono, bool openEditor)
+                         int videoMaxRes, int videoFps, bool recordMono, bool openEditor,
+                         int gifFps, double gifQuality, int gifSizeIdx, bool optimizeGif)
 {
     std::printf("{\"x\":%d,\"y\":%d,\"width\":%d,\"height\":%d,"
                 "\"mode\":\"record\",\"record_type\":\"%s\","
@@ -108,7 +109,9 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                 "\"remember_selection\":%s,\"dim_screen\":%s,"
                 "\"countdown\":%s,"
                 "\"video_max_res\":%d,\"video_fps\":%d,"
-                "\"record_mono\":%s,\"open_editor\":%s}\n",
+                "\"record_mono\":%s,\"open_editor\":%s,"
+                "\"gif_fps\":%d,\"gif_quality\":%.4f,"
+                "\"gif_size_idx\":%d,\"optimize_gif\":%s}\n",
                 sel.x(), sel.y(), sel.width(), sel.height(),
                 recordType,
                 controls ? "true" : "false",
@@ -126,7 +129,11 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                 videoMaxRes,
                 videoFps,
                 recordMono ? "true" : "false",
-                openEditor ? "true" : "false");
+                openEditor ? "true" : "false",
+                gifFps,
+                gifQuality,
+                gifSizeIdx,
+                optimizeGif ? "true" : "false");
     std::fflush(stdout);
 }
 
@@ -152,6 +159,10 @@ int main(int argc, char* argv[])
     QRect restoreSel;
     bool initialMic = false;
     bool initialSpeaker = false;
+    int initialGifFps = 50;
+    double initialGifQuality = 0.75;
+    int initialGifSizeIdx = 0;
+    bool initialGifOptimize = true;
 
     for (int i = 1; i < argc; ++i) {
         if (std::strcmp(argv[i], "--background") == 0 && i + 1 < argc) {
@@ -175,6 +186,22 @@ int main(int argc, char* argv[])
             initialMic = true;
         } else if (std::strcmp(argv[i], "--rec-speaker") == 0) {
             initialSpeaker = true;
+        } else if (QString(argv[i]).startsWith("--gif-fps=")) {
+            bool ok = false;
+            int v = QString(argv[i]).mid(10).toInt(&ok);
+            if (ok && v >= 5 && v <= 60) initialGifFps = v;
+        } else if (QString(argv[i]).startsWith("--gif-quality=")) {
+            bool ok = false;
+            double v = QString(argv[i]).mid(14).toDouble(&ok);
+            if (ok && v >= 0.0 && v <= 1.0) initialGifQuality = v;
+        } else if (QString(argv[i]).startsWith("--gif-size=")) {
+            bool ok = false;
+            int v = QString(argv[i]).mid(11).toInt(&ok);
+            if (ok && v >= 0 && v <= 3) initialGifSizeIdx = v;
+        } else if (std::strcmp(argv[i], "--gif-optimize") == 0) {
+            initialGifOptimize = true;
+        } else if (std::strcmp(argv[i], "--no-gif-optimize") == 0) {
+            initialGifOptimize = false;
         }
     }
 
@@ -301,6 +328,10 @@ int main(int argc, char* argv[])
     if (!restoreSel.isNull() && restoreSel.isValid()) {
         overlay.setInitialSelection(restoreSel);
     }
+    overlay.setInitialGifFps(initialGifFps);
+    overlay.setInitialGifQuality(initialGifQuality);
+    overlay.setInitialGifSizeIdx(initialGifSizeIdx);
+    overlay.setInitialGifOptimize(initialGifOptimize);
     overlay.show();
 
     const int ret = app.exec();
@@ -365,7 +396,11 @@ int main(int argc, char* argv[])
                            overlay.recordVideoMaxRes(),
                            overlay.recordVideoFps(),
                            overlay.recordMono(),
-                           overlay.recordOpenEditor());
+                           overlay.recordOpenEditor(),
+                           overlay.recordGifFps(),
+                           overlay.recordGifQuality(),
+                           overlay.recordGifSizeIdx(),
+                           overlay.recordOptimizeGif());
         return 0;
     }
 

--- a/src/capture_overlay.rs
+++ b/src/capture_overlay.rs
@@ -191,6 +191,11 @@ pub struct RecordingRequest {
     pub video_fps: u8,
     pub record_mono: bool,
     pub open_editor: bool,
+    // GIF tab settings
+    pub gif_fps: u8,
+    pub gif_quality: f64,
+    pub gif_size_idx: u8,
+    pub optimize_gif: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -387,6 +392,14 @@ pub fn capture_area_file_via_cpp() -> Result<AreaCapturePathResult, SelectionErr
     if config.rec_speaker {
         extra_args.push("--rec-speaker".into());
     }
+    extra_args.push(format!("--gif-fps={}", config.rec_gif_fps));
+    extra_args.push(format!("--gif-quality={:.4}", config.rec_gif_quality));
+    extra_args.push(format!("--gif-size={}", config.rec_gif_size_idx));
+    if config.rec_gif_optimize {
+        extra_args.push("--gif-optimize".into());
+    } else {
+        extra_args.push("--no-gif-optimize".into());
+    }
 
     let arg_refs: Vec<&str> = extra_args.iter().map(|s| s.as_str()).collect();
     eprintln!(
@@ -538,6 +551,12 @@ fn parse_recording_json(json: &str) -> Result<RecordingRequest, SelectionError> 
     let video_fps = extract_int(json, "video_fps").unwrap_or(1) as u8; // Default to 30fps (index 1)
     let record_mono = extract_bool(json, "record_mono").unwrap_or(false);
     let open_editor = extract_bool(json, "open_editor").unwrap_or(false);
+    let gif_fps = extract_int(json, "gif_fps").unwrap_or(50).clamp(5, 60) as u8;
+    let gif_quality = extract_float(json, "gif_quality")
+        .unwrap_or(0.75)
+        .clamp(0.0, 1.0);
+    let gif_size_idx = extract_int(json, "gif_size_idx").unwrap_or(0).clamp(0, 3) as u8;
+    let optimize_gif = extract_bool(json, "optimize_gif").unwrap_or(true);
 
     Ok(RecordingRequest {
         x,
@@ -561,6 +580,10 @@ fn parse_recording_json(json: &str) -> Result<RecordingRequest, SelectionError> 
         video_fps,
         record_mono,
         open_editor,
+        gif_fps,
+        gif_quality,
+        gif_size_idx,
+        optimize_gif,
     })
 }
 
@@ -605,6 +628,18 @@ fn extract_int(json: &str, key: &str) -> Option<i32> {
     let rest = json[start..].trim_start();
     let end = rest
         .find(|c: char| !c.is_ascii_digit() && c != '-')
+        .unwrap_or(rest.len());
+    rest[..end].parse().ok()
+}
+
+fn extract_float(json: &str, key: &str) -> Option<f64> {
+    let needle = format!("\"{}\":", key);
+    let start = json.find(&needle)? + needle.len();
+    let rest = json[start..].trim_start();
+    let end = rest
+        .find(|c: char| {
+            !c.is_ascii_digit() && c != '-' && c != '.' && c != 'e' && c != 'E' && c != '+'
+        })
         .unwrap_or(rest.len());
     rest[..end].parse().ok()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,11 @@ pub struct AppConfig {
     pub rec_video_fps: u8,
     pub rec_video_mono: bool,
     pub rec_video_open_editor: bool,
+    // Recording GIF tab settings
+    pub rec_gif_fps: u8,
+    pub rec_gif_quality: f64,
+    pub rec_gif_size_idx: u8,
+    pub rec_gif_optimize: bool,
     pub rec_mic: bool,
     pub rec_speaker: bool,
 }
@@ -84,6 +89,10 @@ impl Default for AppConfig {
             rec_video_fps: 1,     // 1 = 30fps
             rec_video_mono: false,
             rec_video_open_editor: false,
+            rec_gif_fps: 50,
+            rec_gif_quality: 0.75,
+            rec_gif_size_idx: 0,
+            rec_gif_optimize: true,
             rec_mic: false,
             rec_speaker: false,
         }
@@ -108,6 +117,9 @@ impl AppConfig {
         {
             self.after_capture_show_quick_access = DEFAULT_AFTER_CAPTURE_SHOW_QUICK_ACCESS;
         }
+        self.rec_gif_fps = self.rec_gif_fps.clamp(5, 60);
+        self.rec_gif_quality = self.rec_gif_quality.clamp(0.0, 1.0);
+        self.rec_gif_size_idx = self.rec_gif_size_idx.min(3);
         self
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1023,6 +1023,10 @@ fn run_capture(args: &[String]) {
                 cfg.rec_video_fps = request.video_fps;
                 cfg.rec_video_mono = request.record_mono;
                 cfg.rec_video_open_editor = request.open_editor;
+                cfg.rec_gif_fps = request.gif_fps;
+                cfg.rec_gif_quality = request.gif_quality;
+                cfg.rec_gif_size_idx = request.gif_size_idx;
+                cfg.rec_gif_optimize = request.optimize_gif;
 
                 // Remember selection area
                 if request.remember_selection {
@@ -1091,6 +1095,25 @@ fn run_capture(args: &[String]) {
                     3 => 60,
                     _ => 30,
                 };
+                let (fps, gif_quality, gif_optimize, gif_max_width) = if matches!(
+                    request.record_type,
+                    apexshot::capture_overlay::RecordingType::Gif
+                ) {
+                    let gw = match request.gif_size_idx {
+                        0 => Some(800u32),
+                        1 => Some(640u32),
+                        2 => Some(480u32),
+                        _ => None,
+                    };
+                    (
+                        request.gif_fps as u32,
+                        request.gif_quality,
+                        request.optimize_gif,
+                        gw,
+                    )
+                } else {
+                    (fps, 0.75_f64, true, Some(800u32))
+                };
 
                 // Build recording config
                 let rec_config = RecordingConfig {
@@ -1108,6 +1131,9 @@ fn run_capture(args: &[String]) {
                     speaker_enabled: request.speaker,
                     mic_source: None,
                     speaker_source: None,
+                    gif_quality,
+                    gif_optimize,
+                    gif_max_width,
                 };
 
                 eprintln!("Starting recording to {:?}...", output_path);

--- a/src/recording/mod.rs
+++ b/src/recording/mod.rs
@@ -60,6 +60,10 @@ pub struct RecordingConfig {
     pub speaker_enabled: bool,
     pub mic_source: Option<String>,
     pub speaker_source: Option<String>,
+    // GIF-specific settings
+    pub gif_quality: f64,
+    pub gif_optimize: bool,
+    pub gif_max_width: Option<u32>,
 }
 
 impl Default for RecordingConfig {
@@ -81,6 +85,9 @@ impl Default for RecordingConfig {
             speaker_enabled: false,
             mic_source: None,
             speaker_source: None,
+            gif_quality: 0.75,
+            gif_optimize: true,
+            gif_max_width: Some(800),
         }
     }
 }
@@ -832,6 +839,22 @@ async fn record_gif_rust_with_optional_stop(
 
                             println!("Detected stream: {}x{}", width, height);
 
+                            let max_colors = ((32.0 + 224.0 * config.gif_quality) as u32).clamp(32, 256);
+                            let dither = if config.gif_quality >= 0.5 {
+                                "floyd_steinberg"
+                            } else {
+                                "bayer:bayer_scale=5"
+                            };
+                            let stats_mode = if config.gif_optimize { "diff" } else { "full" };
+                            let scale_prefix = match config.gif_max_width {
+                                Some(max_w) if width > max_w => format!("scale={}:-1,", max_w),
+                                _ => String::new(),
+                            };
+                            let vf_filter = format!(
+                                "{}split[s0][s1];[s0]palettegen=max_colors={}:stats_mode={}[p];[s1][p]paletteuse=dither={}",
+                                scale_prefix, max_colors, stats_mode, dither
+                            );
+
                             let child = Command::new("ffmpeg")
                                 .arg("-y") // Overwrite
                                 .arg("-loglevel").arg("warning")
@@ -841,8 +864,7 @@ async fn record_gif_rust_with_optional_stop(
                                 .arg("-s").arg(format!("{}x{}", width, height))
                                 .arg("-r").arg(gif_fps.to_string())
                                 .arg("-i").arg("pipe:0")
-                                // High quality GIF palette generation
-                                .arg("-vf").arg("split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse")
+                                .arg("-vf").arg(&vf_filter)
                                 .arg(&config.output_path)
                                 .stdin(Stdio::piped())
                                 .stdout(Stdio::null())


### PR DESCRIPTION
This PR implements end-to-end GIF tab settings: persistent configuration, continuous slider drag support, and FFmpeg pipeline integration following the Video tab architecture.

### C++ Overlay
- **Fixed GIF slider drag**: Added `m_gifFpsDragging`/`m_gifQualityDragging` flags and cached track rects in `CaptureOverlay_Events.cpp` so FPS/Quality sliders update continuously during mouse drag, matching the click/keystroke slider interaction pattern
- **GIF accessors/setters**: Added `recordGifFps()`, `recordGifQuality()`, `recordSizeIdx()`, `recordOptimizeGif()` and initial-value setters in `CaptureOverlay.h`
- **JSON output**: Updated `printRecordingJson` to emit `gif_fps`, `gif_quality`, `gif_size_idx`, `optimize_gif` and pass values from the record call site
- **Config reload**: Added CLI arg parsing for `--gif-fps`, `--gif-quality`, `--gif-size`, `--gif-optimize/--no-gif-optimize` and apply initial values after overlay construction

### Rust Backend
- **AppConfig**: Added `rec_gif_fps: u8`, `rec_gif_quality: f64`, `rec_gif_size_idx: u8`, `rec_gif_optimize: bool` with defaults (50, 0.75, 0, true) and clamping in `sanitized()`
- **RecordingRequest**: Extended with `gif_fps`, `gif_quality`, `gif_size_idx`, `optimize_gif` fields; added `extract_float()` helper for JSON parsing
- **CLI passing**: Pass GIF config values as overlay CLI args in `capture_area_file_via_cpp`
- **RecordingConfig**: Added `gif_quality`, `gif_optimize`, `gif_max_width` fields with defaults
- **FFmpeg pipeline**: Dynamic `-vf` construction in `record_gif_rust_with_optional_stop`:
  - Quality maps to `palettegen=max_colors` (32-256) and `paletteuse=dither` (`floyd_steinberg` for ≥0.5 quality, `bayer:bayer_scale=5` otherwise)
  - Optimize maps to `stats_mode=diff` (true) or `full` (false)
  - Size index maps to `scale=W:-1` prefix only when source width exceeds max (800/640/480/None)
- **Config save**: Persist GIF settings to AppConfig on recording start in `src/main.rs` and build GIF-specific `RecordingConfig` when `record_type == Gif`

<a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/pull/9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/task/6e41de67-3d02-4cb8-ac21-7a4656e77e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-3&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-3"><img alt="APE-3 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-3"></picture></a>