### PR TITLE
Feature: Implement recording controls bar with fullscreen awareness

### DIFF
--- a/capture-overlay/src/CaptureOverlay.h
+++ b/capture-overlay/src/CaptureOverlay.h
@@ -68,6 +68,7 @@ public:
     bool recordRequested() const { return m_captureIntent == CaptureIntent::Record; }
     RecordType recordType() const { return m_recordType; }
     bool recordControlsEnabled() const { return m_recControls; }
+    bool recordFullscreen() const { return m_fullscreenMode; }
     bool recordMicEnabled() const { return m_recMic; }
     bool recordSpeakerEnabled() const { return m_recSpeaker; }
     bool recordClicksEnabled() const { return m_recClicks; }

--- a/capture-overlay/src/main.cpp
+++ b/capture-overlay/src/main.cpp
@@ -98,7 +98,8 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                          bool showCursor, bool rememberSelection,
                          bool dimScreen, bool countdown,
                          int videoMaxRes, int videoFps, bool recordMono, bool openEditor,
-                         int gifFps, double gifQuality, int gifSizeIdx, bool optimizeGif)
+                         int gifFps, double gifQuality, int gifSizeIdx, bool optimizeGif,
+                         bool fullscreen)
 {
     std::printf("{\"x\":%d,\"y\":%d,\"width\":%d,\"height\":%d,"
                 "\"mode\":\"record\",\"record_type\":\"%s\","
@@ -111,7 +112,7 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                 "\"video_max_res\":%d,\"video_fps\":%d,"
                 "\"record_mono\":%s,\"open_editor\":%s,"
                 "\"gif_fps\":%d,\"gif_quality\":%.4f,"
-                "\"gif_size_idx\":%d,\"optimize_gif\":%s}\n",
+                "\"gif_size_idx\":%d,\"optimize_gif\":%s,\"fullscreen\":%s}\n",
                 sel.x(), sel.y(), sel.width(), sel.height(),
                 recordType,
                 controls ? "true" : "false",
@@ -133,7 +134,8 @@ void printRecordingJson(const QRect& sel, const char* recordType,
                 gifFps,
                 gifQuality,
                 gifSizeIdx,
-                optimizeGif ? "true" : "false");
+                optimizeGif ? "true" : "false",
+                fullscreen ? "true" : "false");
     std::fflush(stdout);
 }
 
@@ -400,7 +402,8 @@ int main(int argc, char* argv[])
                            overlay.recordGifFps(),
                            overlay.recordGifQuality(),
                            overlay.recordGifSizeIdx(),
-                           overlay.recordOptimizeGif());
+                           overlay.recordOptimizeGif(),
+                           overlay.recordFullscreen());
         return 0;
     }
 

--- a/src/capture_overlay.rs
+++ b/src/capture_overlay.rs
@@ -196,6 +196,7 @@ pub struct RecordingRequest {
     pub gif_quality: f64,
     pub gif_size_idx: u8,
     pub optimize_gif: bool,
+    pub fullscreen: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -557,6 +558,7 @@ fn parse_recording_json(json: &str) -> Result<RecordingRequest, SelectionError> 
         .clamp(0.0, 1.0);
     let gif_size_idx = extract_int(json, "gif_size_idx").unwrap_or(0).clamp(0, 3) as u8;
     let optimize_gif = extract_bool(json, "optimize_gif").unwrap_or(true);
+    let fullscreen = extract_bool(json, "fullscreen").unwrap_or(false);
 
     Ok(RecordingRequest {
         x,
@@ -584,6 +586,7 @@ fn parse_recording_json(json: &str) -> Result<RecordingRequest, SelectionError> 
         gif_quality,
         gif_size_idx,
         optimize_gif,
+        fullscreen,
     })
 }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -107,11 +107,9 @@ pub const DAEMON_OBJECT_PATH: &str = "/org/apexshot/Daemon";
 pub const DAEMON_INTERFACE: &str = "org.apexshot.Daemon";
 
 /// Current mic level (f64 bits stored as u64), updated by mic monitoring thread.
-static MIC_LEVEL: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0); // 0.0f64.to_bits()
+static MIC_LEVEL: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0); // 0.0f64.to_bits()
 /// Current system audio level (f64 bits stored as u64), updated by speaker monitoring thread.
-static SPEAKER_LEVEL: std::sync::atomic::AtomicU64 =
-    std::sync::atomic::AtomicU64::new(0);
+static SPEAKER_LEVEL: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
 /// Try to trigger an action on an already-running daemon via D-Bus.
 /// Returns `true` if the daemon was found and the call succeeded.
@@ -902,7 +900,6 @@ impl DaemonIpc {
     }
 }
 
-
 fn start_audio_level_stream(
     label: &'static str,
     stream_name: &'static str,
@@ -1000,7 +997,9 @@ fn start_audio_level_stream(
                     None => return,
                 };
                 let datas = buf.datas_mut();
-                if datas.is_empty() { return; }
+                if datas.is_empty() {
+                    return;
+                }
 
                 let mut peak: f32 = 0.0;
                 for data in datas.iter_mut() {
@@ -1011,7 +1010,9 @@ fn start_audio_level_stream(
                             let n_samples = n_bytes / std::mem::size_of::<f32>();
                             for j in 0..n_samples {
                                 let s = unsafe { *ptr.add(j) }.abs();
-                                if s > peak { peak = s; }
+                                if s > peak {
+                                    peak = s;
+                                }
                             }
                         }
                     }
@@ -1048,7 +1049,11 @@ fn start_audio_level_stream(
                 // Noise gate: ignore quiet audio to avoid picking up speaker bleed
                 // Only applies to mic stream (not speaker/sink monitor)
                 let gated = if !capture_sink {
-                    if raw_level < 0.15 { 0.0 } else { raw_level }
+                    if raw_level < 0.15 {
+                        0.0
+                    } else {
+                        raw_level
+                    }
                 } else {
                     raw_level
                 };
@@ -1128,10 +1133,21 @@ async fn run_dbus_server(tx: std::sync::mpsc::Sender<DaemonAction>) -> anyhow::R
 
     // Mic: explicitly target physical input device to avoid picking up system audio
     // Falls back to default input if specific device not found
-    start_audio_level_stream("mic", "apexshot-mic-monitor",
-        Some("alsa_input.pci-0000_00_1f.3.analog-stereo"), false, &MIC_LEVEL);
+    start_audio_level_stream(
+        "mic",
+        "apexshot-mic-monitor",
+        Some("alsa_input.pci-0000_00_1f.3.analog-stereo"),
+        false,
+        &MIC_LEVEL,
+    );
     // Speaker: capture from sink monitor (digital tap of system audio output)
-    start_audio_level_stream("speaker", "apexshot-speaker-monitor", None, true, &SPEAKER_LEVEL);
+    start_audio_level_stream(
+        "speaker",
+        "apexshot-speaker-monitor",
+        None,
+        true,
+        &SPEAKER_LEVEL,
+    );
 
     eprintln!("[daemon] D-Bus IPC ready on {DAEMON_BUS_NAME}");
     std::future::pending::<()>().await;
@@ -2356,13 +2372,13 @@ fn handle_capture_window(state: Arc<Mutex<DaemonState>>) {
 
 async fn handle_record_screen(_tx: std::sync::mpsc::Sender<DaemonAction>) {
     use crate::recording::{
-        run_recording_stop_overlay, start_recording_with_stop, RecordingConfig,
+        run_recording_stop_overlay, start_recording_with_stop, RecordingConfig, StopAction,
     };
 
     eprintln!("[daemon] Starting screen recording…");
 
     let config = RecordingConfig::default();
-    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<StopAction>();
 
     let record_join = tokio::spawn(async move { start_recording_with_stop(config, stop_rx).await });
 
@@ -2377,7 +2393,13 @@ async fn handle_record_screen(_tx: std::sync::mpsc::Sender<DaemonAction>) {
     }
 
     match record_join.await {
-        Ok(Ok(path)) => eprintln!("[daemon] Recording saved: {}", path.display()),
+        Ok(Ok((path, StopAction::Discard))) => {
+            let _ = std::fs::remove_file(&path);
+            eprintln!("[daemon] Recording discarded.");
+        }
+        Ok(Ok((path, StopAction::Save))) => {
+            eprintln!("[daemon] Recording saved: {}", path.display())
+        }
         Ok(Err(e)) => eprintln!("[daemon] Recording error: {e}"),
         Err(e) => eprintln!("[daemon] Recording task panicked: {e}"),
     }
@@ -2386,7 +2408,8 @@ async fn handle_record_screen(_tx: std::sync::mpsc::Sender<DaemonAction>) {
 async fn handle_record_area(_tx: std::sync::mpsc::Sender<DaemonAction>) {
     use crate::capture_overlay::run_capture_overlay;
     use crate::recording::{
-        run_recording_stop_overlay, start_recording_with_stop, RecordingConfig,
+        run_recording_controls, start_recording_with_stop, RecordingConfig,
+        RecordingControlsParams, StopAction,
     };
 
     eprintln!("[daemon] Selecting area for recording…");
@@ -2427,12 +2450,20 @@ async fn handle_record_area(_tx: std::sync::mpsc::Sender<DaemonAction>) {
         area.x, area.y, area.width, area.height
     );
 
-    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<StopAction>();
 
     let record_join = tokio::spawn(async move { start_recording_with_stop(config, stop_rx).await });
 
+    let params = RecordingControlsParams {
+        capture_x: area.x,
+        capture_y: area.y,
+        capture_w: area.width,
+        capture_h: area.height,
+        is_fullscreen: false,
+        show_timer: false,
+    };
     let overlay_result =
-        tokio::task::spawn_blocking(move || run_recording_stop_overlay(stop_tx)).await;
+        tokio::task::spawn_blocking(move || run_recording_controls(params, stop_tx)).await;
 
     match overlay_result {
         Ok(Ok(())) => {}
@@ -2441,7 +2472,13 @@ async fn handle_record_area(_tx: std::sync::mpsc::Sender<DaemonAction>) {
     }
 
     match record_join.await {
-        Ok(Ok(path)) => eprintln!("[daemon] Recording saved: {}", path.display()),
+        Ok(Ok((path, StopAction::Discard))) => {
+            let _ = std::fs::remove_file(&path);
+            eprintln!("[daemon] Recording discarded.");
+        }
+        Ok(Ok((path, StopAction::Save))) => {
+            eprintln!("[daemon] Recording saved: {}", path.display())
+        }
         Ok(Err(e)) => eprintln!("[daemon] Recording error: {e}"),
         Err(e) => eprintln!("[daemon] Recording task panicked: {e}"),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,8 @@ use apexshot::{
     },
     ocr::{extract_text_from_path, OcrConfig},
     recording::{
-        copy_to_clipboard as copy_recording_to_clipboard, run_recording_stop_overlay,
-        start_recording, start_recording_with_stop, RecordingConfig,
+        copy_to_clipboard as copy_recording_to_clipboard, run_recording_controls, start_recording,
+        start_recording_with_stop, RecordingConfig, RecordingControlsParams, StopAction,
     },
     show_settings_window,
 };
@@ -1139,21 +1139,32 @@ fn run_capture(args: &[String]) {
                 eprintln!("Starting recording to {:?}...", output_path);
 
                 // Start recording with stop overlay
-                let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+                let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<StopAction>();
 
-                // Launch stop overlay in background thread
                 let overlay_handle = if request.controls {
+                    let params = RecordingControlsParams {
+                        capture_x: request.x,
+                        capture_y: request.y,
+                        capture_w: request.width,
+                        capture_h: request.height,
+                        is_fullscreen: request.fullscreen,
+                        show_timer: request.display_rec_time,
+                    };
                     Some(std::thread::spawn(move || {
-                        let _ = run_recording_stop_overlay(stop_tx);
+                        let _ = run_recording_controls(params, stop_tx);
                     }))
                 } else {
-                    // No controls shown — user must use Ctrl+C to stop
+                    drop(stop_tx);
                     None
                 };
 
                 let handle = tokio::runtime::Handle::current();
                 match handle.block_on(start_recording_with_stop(rec_config, stop_rx)) {
-                    Ok(path) => {
+                    Ok((path, StopAction::Discard)) => {
+                        eprintln!("Recording discarded — deleting {:?}", path);
+                        let _ = std::fs::remove_file(&path);
+                    }
+                    Ok((path, StopAction::Save)) => {
                         eprintln!("Recording saved to {:?}", path);
                     }
                     Err(err) => {
@@ -1678,15 +1689,35 @@ async fn run_record(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let final_path = if overlay_stop {
-        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<StopAction>();
         let join = tokio::spawn(async move { start_recording_with_stop(config, stop_rx).await });
 
-        // Blocks until user hits Esc or clicks Stop.
-        run_recording_stop_overlay(stop_tx)
-            .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
+        run_recording_controls(
+            RecordingControlsParams {
+                capture_x: 0,
+                capture_y: 0,
+                capture_w: 0,
+                capture_h: 0,
+                is_fullscreen: true,
+                show_timer: false,
+            },
+            stop_tx,
+        )
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)?;
 
-        join.await
+        match join
+            .await
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)??
+        {
+            (path, StopAction::Discard) => {
+                let _ = std::fs::remove_file(&path);
+                return Ok(());
+            }
+            (path, StopAction::Save) => {
+                eprintln!("Recording saved: {:?}", path);
+                path
+            }
+        }
     } else {
         start_recording(config)
             .await

--- a/src/recording/mod.rs
+++ b/src/recording/mod.rs
@@ -8,7 +8,10 @@ use tokio::sync::oneshot;
 use zbus::zvariant::OwnedValue;
 
 mod stop_overlay;
-pub use stop_overlay::{run_recording_stop_overlay, StopOverlayError};
+pub use stop_overlay::{
+    run_recording_controls, run_recording_stop_overlay, RecordingControlsParams, StopAction,
+    StopOverlayError,
+};
 
 pub mod countdown_overlay;
 pub mod dim_overlay;
@@ -146,21 +149,23 @@ const PROFILES: &[EncoderProfile] = &[
 
 /// Start a recording session
 pub async fn start_recording(config: RecordingConfig) -> RecordResult<PathBuf> {
-    start_recording_with_optional_stop(config, None).await
+    start_recording_with_optional_stop(config, None)
+        .await
+        .map(|(path, _)| path)
 }
 
 /// Start a recording session and stop when `stop_rx` resolves (in addition to Ctrl+C).
 pub async fn start_recording_with_stop(
     config: RecordingConfig,
-    stop_rx: oneshot::Receiver<()>,
-) -> RecordResult<PathBuf> {
+    stop_rx: oneshot::Receiver<StopAction>,
+) -> RecordResult<(PathBuf, StopAction)> {
     start_recording_with_optional_stop(config, Some(stop_rx)).await
 }
 
 async fn start_recording_with_optional_stop(
     config: RecordingConfig,
-    stop_rx: Option<oneshot::Receiver<()>>,
-) -> RecordResult<PathBuf> {
+    stop_rx: Option<oneshot::Receiver<StopAction>>,
+) -> RecordResult<(PathBuf, StopAction)> {
     // 1. Initialize GStreamer
     gst::init().map_err(|e| RecordError::InitError(e.to_string()))?;
 
@@ -227,15 +232,19 @@ async fn start_recording_with_optional_stop(
 
     let stop_fut = async {
         if let Some(rx) = stop_rx {
-            let _ = rx.await;
+            match rx.await {
+                Ok(action) => action,
+                Err(_) => futures_util::future::pending::<StopAction>().await,
+            }
         } else {
-            futures_util::future::pending::<()>().await;
+            futures_util::future::pending::<StopAction>().await
         }
     };
     tokio::pin!(stop_fut);
 
     // Phase 1: Recording until Ctrl+C or Error
     let mut stopping = false;
+    let mut stop_action = StopAction::Save;
     loop {
         tokio::select! {
             _ = &mut ctrl_c => {
@@ -244,7 +253,8 @@ async fn start_recording_with_optional_stop(
                 stopping = true;
                 break;
             }
-            _ = &mut stop_fut => {
+            action = &mut stop_fut => {
+                stop_action = action;
                 println!("\nStopping recording... Finalizing file...");
                 pipeline.send_event(gst::event::Eos::new());
                 stopping = true;
@@ -313,15 +323,17 @@ async fn start_recording_with_optional_stop(
         .set_state(gst::State::Null)
         .map_err(|e| RecordError::GStreamerError(format!("Failed to set state to Null: {}", e)))?;
 
-    println!("Recording saved to {:?}", final_path);
-    if let Ok(metadata) = std::fs::metadata(&final_path) {
-        println!(
-            "File size: {:.2} MB",
-            metadata.len() as f64 / 1024.0 / 1024.0
-        );
+    if stop_action == StopAction::Save {
+        println!("Recording saved to {:?}", final_path);
+        if let Ok(metadata) = std::fs::metadata(&final_path) {
+            println!(
+                "File size: {:.2} MB",
+                metadata.len() as f64 / 1024.0 / 1024.0
+            );
+        }
     }
 
-    Ok(final_path)
+    Ok((final_path, stop_action))
 }
 
 pub fn copy_to_clipboard(path: &PathBuf) -> RecordResult<()> {
@@ -726,8 +738,8 @@ fn get_x11_source(config: &RecordingConfig) -> RecordResult<String> {
 
 async fn record_gif_rust_with_optional_stop(
     config: RecordingConfig,
-    stop_rx: Option<oneshot::Receiver<()>>,
-) -> RecordResult<PathBuf> {
+    stop_rx: Option<oneshot::Receiver<StopAction>>,
+) -> RecordResult<(PathBuf, StopAction)> {
     use std::io::Write;
     use std::process::{Command, Stdio};
 
@@ -803,14 +815,18 @@ async fn record_gif_rust_with_optional_stop(
 
     let stop_fut = async {
         if let Some(rx) = stop_rx {
-            let _ = rx.await;
+            match rx.await {
+                Ok(action) => action,
+                Err(_) => futures_util::future::pending::<StopAction>().await,
+            }
         } else {
-            futures_util::future::pending::<()>().await;
+            futures_util::future::pending::<StopAction>().await
         }
     };
     tokio::pin!(stop_fut);
 
     let mut stopping = false;
+    let mut stop_action = StopAction::Save;
     let mut ffmpeg_child: Option<std::process::Child> = None;
 
     loop {
@@ -819,7 +835,8 @@ async fn record_gif_rust_with_optional_stop(
                 println!("\nStopping recording...");
                 stopping = true;
             }
-            _ = &mut stop_fut => {
+            action = &mut stop_fut => {
+                stop_action = action;
                 println!("\nStopping recording...");
                 stopping = true;
             }
@@ -936,6 +953,8 @@ async fn record_gif_rust_with_optional_stop(
         return Err(RecordError::GifError("No frames captured".into()));
     }
 
-    println!("GIF saved to {:?}", config.output_path);
-    Ok(config.output_path)
+    if stop_action == StopAction::Save {
+        println!("GIF saved to {:?}", config.output_path);
+    }
+    Ok((config.output_path, stop_action))
 }

--- a/src/recording/stop_overlay.rs
+++ b/src/recording/stop_overlay.rs
@@ -1,12 +1,28 @@
-use gtk4::gdk::Key;
+use gdk4x11::X11Surface;
+use gtk4::gdk::{self, Key};
 use gtk4::{
     glib::{self, clone},
     prelude::*,
-    Application, ApplicationWindow, Button, EventControllerKey, Label, Orientation,
+    Application, ApplicationWindow, Box as GtkBox, Button, CssProvider, DrawingArea,
+    EventControllerKey, GestureDrag, Label, Orientation, Separator,
 };
+use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+use std::cell::Cell;
+use std::rc::Rc;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::oneshot;
+use x11rb::wrapper::ConnectionExt;
+use x11rb::{
+    connection::Connection,
+    protocol::xproto::{self, ConnectionExt as _},
+};
+
+const BAR_W: i32 = 380;
+const BAR_H: i32 = 56;
+const MARGIN: i32 = 24;
+const DOCK_SAFE: i32 = 64;
 
 #[derive(Debug, Error)]
 pub enum StopOverlayError {
@@ -14,12 +30,28 @@ pub enum StopOverlayError {
     InitError(String),
 }
 
-/// Shows a small window that lets the user stop an in-progress recording.
-///
-/// - Press `Esc` or click the button to stop.
-/// - This is intended for Wayland hotkey workflows where you can't rely on Ctrl+C.
-pub fn run_recording_stop_overlay(stop_tx: oneshot::Sender<()>) -> Result<(), StopOverlayError> {
-    let stop_tx: Arc<Mutex<Option<oneshot::Sender<()>>>> = Arc::new(Mutex::new(Some(stop_tx)));
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopAction {
+    Save,
+    Discard,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct RecordingControlsParams {
+    pub capture_x: i32,
+    pub capture_y: i32,
+    pub capture_w: i32,
+    pub capture_h: i32,
+    pub is_fullscreen: bool,
+    pub show_timer: bool,
+}
+
+pub fn run_recording_controls(
+    params: RecordingControlsParams,
+    stop_tx: oneshot::Sender<StopAction>,
+) -> Result<(), StopOverlayError> {
+    let stop_tx: Arc<Mutex<Option<oneshot::Sender<StopAction>>>> =
+        Arc::new(Mutex::new(Some(stop_tx)));
 
     let app = Application::builder()
         .application_id("com.apexshot.recording")
@@ -27,79 +59,481 @@ pub fn run_recording_stop_overlay(stop_tx: oneshot::Sender<()>) -> Result<(), St
 
     let stop_tx_activate = stop_tx.clone();
     app.connect_activate(move |application| {
-        setup_window(application, stop_tx_activate.clone());
+        setup_window(application, params, stop_tx_activate.clone());
     });
 
     let _ = app.run_with_args::<String>(&[]);
     Ok(())
 }
 
-fn setup_window(app: &Application, stop_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>) {
+pub fn run_recording_stop_overlay(
+    stop_tx: oneshot::Sender<StopAction>,
+) -> Result<(), StopOverlayError> {
+    run_recording_controls(
+        RecordingControlsParams {
+            capture_x: 0,
+            capture_y: 0,
+            capture_w: 0,
+            capture_h: 0,
+            is_fullscreen: true,
+            show_timer: false,
+        },
+        stop_tx,
+    )
+}
+
+fn compute_bar_position(
+    params: &RecordingControlsParams,
+    screen_w: i32,
+    screen_h: i32,
+) -> (i32, i32) {
+    if params.is_fullscreen {
+        let x = (screen_w - BAR_W) / 2;
+        let y = MARGIN;
+        return (x, y);
+    }
+
+    let x = (params.capture_x + (params.capture_w - BAR_W) / 2)
+        .clamp(MARGIN, (screen_w - BAR_W - MARGIN).max(MARGIN));
+
+    let y_below = params.capture_y + params.capture_h + 12;
+    if y_below + BAR_H + DOCK_SAFE <= screen_h {
+        return (x, y_below);
+    }
+
+    let y_above = params.capture_y - BAR_H - 12;
+    if y_above >= MARGIN {
+        return (x, y_above);
+    }
+
+    ((screen_w - BAR_W) / 2, MARGIN)
+}
+
+fn setup_window(
+    app: &Application,
+    params: RecordingControlsParams,
+    stop_tx: Arc<Mutex<Option<oneshot::Sender<StopAction>>>>,
+) {
+    install_controls_css();
+
+    let (screen_w, screen_h) = display_size().unwrap_or((1920, 1080));
+    let initial_pos = compute_bar_position(&params, screen_w, screen_h);
+    let current_pos = Rc::new(Cell::new(initial_pos));
+    let drag_start_pos = Rc::new(Cell::new(initial_pos));
+
     let window = ApplicationWindow::builder()
         .application(app)
-        .title("Recording")
-        .default_width(360)
-        .default_height(120)
+        .title("ApexShot Recording")
+        .default_width(BAR_W)
+        .default_height(BAR_H)
         .decorated(false)
         .resizable(false)
         .build();
 
-    let vbox = gtk4::Box::new(Orientation::Vertical, 12);
-    vbox.set_margin_top(16);
-    vbox.set_margin_bottom(16);
-    vbox.set_margin_start(16);
-    vbox.set_margin_end(16);
+    let is_wayland = std::env::var_os("WAYLAND_DISPLAY").is_some();
+    let layer_shell_active = is_wayland && gtk4_layer_shell::is_supported();
+    if layer_shell_active {
+        let (pos_x, pos_y) = initial_pos;
+        window.init_layer_shell();
+        window.set_layer(Layer::Top);
+        window.set_anchor(Edge::Top, true);
+        window.set_anchor(Edge::Left, true);
+        window.set_anchor(Edge::Bottom, false);
+        window.set_anchor(Edge::Right, false);
+        window.set_margin(Edge::Top, pos_y);
+        window.set_margin(Edge::Left, pos_x);
+        window.set_keyboard_mode(KeyboardMode::OnDemand);
+        window.set_exclusive_zone(-1);
+        window.set_namespace(Some("apexshot-recording-controls"));
+    }
 
-    let label = Label::new(Some("Recording… Press Esc to stop"));
-    label.set_xalign(0.0);
-
-    let btn = Button::with_label("Stop");
-
-    let window_weak = window.downgrade();
-    let stop_tx_btn = stop_tx.clone();
-    btn.connect_clicked(clone!(
-        #[strong]
-        stop_tx_btn,
-        move |_| {
-            send_stop(&stop_tx_btn);
-            if let Some(window) = window_weak.upgrade() {
-                window.close();
+    if !layer_shell_active {
+        let current_pos_realize = current_pos.clone();
+        window.connect_realize(clone!(
+            #[weak]
+            window,
+            move |_| {
+                suppress_x11_controls_window_type(&window);
+                let _ = request_x11_always_on_top(&window);
+                let (x, y) = current_pos_realize.get();
+                let _ = position_x11_window(&window, x, y);
             }
+        ));
+
+        let current_pos_map = current_pos.clone();
+        window.connect_map(clone!(
+            #[weak]
+            window,
+            move |_| {
+                let (x, y) = current_pos_map.get();
+                let _ = request_x11_always_on_top(&window);
+                let _ = position_x11_window(&window, x, y);
+            }
+        ));
+    }
+
+    let stop_btn = icon_button_with_stop();
+    let pause_btn = icon_button_with_pause();
+    pause_btn.set_sensitive(false);
+
+    let restart_btn = text_button("↺");
+    restart_btn.set_sensitive(false);
+
+    let discard_btn = text_button("🗑");
+    let menu_btn = text_button("≡");
+
+    let timer_label = Label::new(Some("0:00"));
+    timer_label.add_css_class("rec-timer");
+
+    let sep = Separator::new(Orientation::Vertical);
+    sep.add_css_class("rec-separator");
+
+    let bar = GtkBox::new(Orientation::Horizontal, 0);
+    bar.add_css_class("recording-controls-bar");
+    bar.set_margin_top(4);
+    bar.set_margin_bottom(4);
+    bar.set_margin_start(8);
+    bar.set_margin_end(8);
+
+    bar.append(&stop_btn);
+    if params.show_timer {
+        bar.append(&timer_label);
+    }
+    bar.append(&sep);
+    bar.append(&pause_btn);
+    bar.append(&restart_btn);
+    bar.append(&discard_btn);
+    bar.append(&menu_btn);
+
+    window.set_child(Some(&bar));
+
+    if params.show_timer {
+        let elapsed_secs = Rc::new(Cell::new(0u64));
+        let elapsed_secs_timer = elapsed_secs.clone();
+        let timer_label_weak = timer_label.downgrade();
+        glib::timeout_add_local(Duration::from_secs(1), move || {
+            let secs = elapsed_secs_timer.get() + 1;
+            elapsed_secs_timer.set(secs);
+            if let Some(lbl) = timer_label_weak.upgrade() {
+                let mins = secs / 60;
+                let s = secs % 60;
+                lbl.set_text(&format!("{}:{:02}", mins, s));
+                glib::ControlFlow::Continue
+            } else {
+                glib::ControlFlow::Break
+            }
+        });
+    }
+
+    let stop_tx_stop = stop_tx.clone();
+    let window_weak = window.downgrade();
+    stop_btn.connect_clicked(move |_| {
+        send_stop_action(&stop_tx_stop, StopAction::Save);
+        if let Some(window) = window_weak.upgrade() {
+            window.close();
         }
-    ));
+    });
 
-    vbox.append(&label);
-    vbox.append(&btn);
+    let stop_tx_discard = stop_tx.clone();
+    let window_weak_discard = window.downgrade();
+    discard_btn.connect_clicked(move |_| {
+        send_stop_action(&stop_tx_discard, StopAction::Discard);
+        if let Some(window) = window_weak_discard.upgrade() {
+            window.close();
+        }
+    });
 
-    window.set_child(Some(&vbox));
-
-    let key_controller = EventControllerKey::builder()
+    let stop_tx_esc = stop_tx.clone();
+    let window_weak_esc = window.downgrade();
+    let key_ctrl = EventControllerKey::builder()
         .propagation_phase(gtk4::PropagationPhase::Capture)
         .build();
-
-    let stop_tx_key = stop_tx.clone();
-    let window_weak_esc = window.downgrade();
-    key_controller.connect_key_pressed(clone!(
-        #[strong]
-        stop_tx_key,
-        move |_, key, _, _| {
-            if key == Key::Escape {
-                send_stop(&stop_tx_key);
-                if let Some(window) = window_weak_esc.upgrade() {
-                    window.close();
-                }
-                return glib::Propagation::Stop;
+    key_ctrl.connect_key_pressed(move |_, key, _, _| {
+        if key == Key::Escape {
+            send_stop_action(&stop_tx_esc, StopAction::Save);
+            if let Some(window) = window_weak_esc.upgrade() {
+                window.close();
             }
-            glib::Propagation::Proceed
+            return glib::Propagation::Stop;
+        }
+        glib::Propagation::Proceed
+    });
+    window.add_controller(key_ctrl);
+
+    let drag = GestureDrag::new();
+    drag.connect_drag_begin(clone!(
+        #[strong]
+        current_pos,
+        #[strong]
+        drag_start_pos,
+        move |_, _, _| {
+            drag_start_pos.set(current_pos.get());
         }
     ));
+    drag.connect_drag_update(clone!(
+        #[weak]
+        window,
+        #[strong]
+        current_pos,
+        #[strong]
+        drag_start_pos,
+        move |_, dx, dy| {
+            let (start_x, start_y) = drag_start_pos.get();
+            let next_x = (start_x + dx.round() as i32).clamp(0, (screen_w - BAR_W).max(0));
+            let next_y = (start_y + dy.round() as i32).clamp(0, (screen_h - BAR_H).max(0));
+            current_pos.set((next_x, next_y));
+            if layer_shell_active {
+                window.set_margin(Edge::Left, next_x);
+                window.set_margin(Edge::Top, next_y);
+            } else {
+                let _ = position_x11_window(&window, next_x, next_y);
+            }
+        }
+    ));
+    bar.add_controller(drag);
 
-    window.add_controller(key_controller);
     window.present();
 }
 
-fn send_stop(stop_tx: &Arc<Mutex<Option<oneshot::Sender<()>>>>) {
-    if let Some(tx) = stop_tx.lock().ok().and_then(|mut g| g.take()) {
-        let _ = tx.send(());
+fn install_controls_css() {
+    if let Some(display) = gdk::Display::default() {
+        let provider = CssProvider::new();
+        provider.load_from_data(
+            ".recording-controls-bar {                background-color: rgba(28, 28, 30, 0.92);                border-radius: 14px;                border: 1px solid rgba(255,255,255,0.08);            }            .rec-btn {                background: none;                border: none;                padding: 0;                min-width: 44px;                min-height: 44px;                box-shadow: none;            }            .rec-btn:hover {                background-color: rgba(255,255,255,0.10);                border-radius: 8px;            }            .rec-btn:disabled {                opacity: 0.35;            }            .rec-btn label {                color: rgba(255,255,255,0.85);                font-size: 18px;            }            .rec-timer {                color: rgba(220,60,60,1.0);                font-size: 15px;                font-weight: bold;                font-family: monospace;                margin-start: 4px;                margin-end: 10px;            }            .rec-separator {                background-color: rgba(255,255,255,0.15);                min-width: 1px;                margin-top: 12px;                margin-bottom: 12px;                margin-start: 4px;                margin-end: 4px;            }",
+        );
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
+        );
     }
+}
+
+fn icon_button_with_stop() -> Button {
+    let drawing_area = DrawingArea::new();
+    drawing_area.set_content_width(36);
+    drawing_area.set_content_height(36);
+    drawing_area.set_draw_func(|_, cr, w, h| {
+        let cx = w as f64 / 2.0;
+        let cy = h as f64 / 2.0;
+        let radius = (w.min(h) as f64 / 2.0) - 3.0;
+
+        cr.set_source_rgba(1.0, 0.22, 0.22, 1.0);
+        cr.set_line_width(2.2);
+        cr.arc(cx, cy, radius, 0.0, 2.0 * std::f64::consts::PI);
+        let _ = cr.stroke();
+
+        let sq = radius * 0.42;
+        cr.rectangle(cx - sq, cy - sq, sq * 2.0, sq * 2.0);
+        let _ = cr.fill();
+    });
+
+    let button = Button::new();
+    button.set_has_frame(false);
+    button.set_focusable(false);
+    button.set_child(Some(&drawing_area));
+    button.add_css_class("rec-btn");
+    button
+}
+
+fn icon_button_with_pause() -> Button {
+    let drawing_area = DrawingArea::new();
+    drawing_area.set_content_width(36);
+    drawing_area.set_content_height(36);
+    drawing_area.set_draw_func(|_, cr, w, h| {
+        let cx = w as f64 / 2.0;
+        let cy = h as f64 / 2.0;
+        let radius = (w.min(h) as f64 / 2.0) - 3.0;
+
+        cr.set_source_rgba(1.0, 1.0, 1.0, 0.85);
+        cr.set_line_width(2.0);
+        cr.arc(cx, cy, radius, 0.0, 2.0 * std::f64::consts::PI);
+        let _ = cr.stroke();
+
+        let bar_w = radius * 0.20;
+        let bar_h = radius * 0.60;
+        let gap = radius * 0.18;
+        cr.rectangle(cx - gap - bar_w, cy - bar_h / 2.0, bar_w, bar_h);
+        cr.rectangle(cx + gap, cy - bar_h / 2.0, bar_w, bar_h);
+        let _ = cr.fill();
+    });
+
+    let button = Button::new();
+    button.set_has_frame(false);
+    button.set_focusable(false);
+    button.set_child(Some(&drawing_area));
+    button.add_css_class("rec-btn");
+    button
+}
+
+fn text_button(text: &str) -> Button {
+    let button = Button::with_label(text);
+    button.set_has_frame(false);
+    button.set_focusable(false);
+    button.add_css_class("rec-btn");
+    button
+}
+
+fn display_size() -> Option<(i32, i32)> {
+    let display = gdk::Display::default()?;
+    let monitors = display.monitors();
+    let mut max_right = 0;
+    let mut max_bottom = 0;
+    for idx in 0..monitors.n_items() {
+        let Some(item) = monitors.item(idx) else {
+            continue;
+        };
+        let Ok(monitor) = item.downcast::<gdk::Monitor>() else {
+            continue;
+        };
+        let geometry = monitor.geometry();
+        max_right = max_right.max(geometry.x() + geometry.width());
+        max_bottom = max_bottom.max(geometry.y() + geometry.height());
+    }
+    if max_right > 0 && max_bottom > 0 {
+        Some((max_right, max_bottom))
+    } else {
+        None
+    }
+}
+
+fn send_stop_action(stop_tx: &Arc<Mutex<Option<oneshot::Sender<StopAction>>>>, action: StopAction) {
+    if let Some(tx) = stop_tx.lock().ok().and_then(|mut guard| guard.take()) {
+        let _ = tx.send(action);
+    }
+}
+
+fn suppress_x11_controls_window_type(window: &impl IsA<gtk4::Window>) {
+    let Some(surface) = window.as_ref().surface() else {
+        return;
+    };
+    let Ok(x11_surface) = surface.downcast::<X11Surface>() else {
+        return;
+    };
+    let Ok(xid) = u32::try_from(x11_surface.xid()) else {
+        return;
+    };
+    let Ok((conn, _)) = x11rb::connect(None) else {
+        return;
+    };
+
+    if let (Ok(type_cookie), Ok(notif_cookie)) = (
+        conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE"),
+        conn.intern_atom(false, b"_NET_WM_WINDOW_TYPE_NOTIFICATION"),
+    ) {
+        if let (Ok(type_reply), Ok(notif_reply)) = (type_cookie.reply(), notif_cookie.reply()) {
+            let _ = conn.change_property32(
+                xproto::PropMode::REPLACE,
+                xid,
+                type_reply.atom,
+                xproto::AtomEnum::ATOM,
+                &[notif_reply.atom],
+            );
+        }
+    }
+
+    if let Ok(cookie) = conn.intern_atom(false, b"_NET_WM_BYPASS_COMPOSITOR") {
+        if let Ok(reply) = cookie.reply() {
+            let _ = conn.change_property32(
+                xproto::PropMode::REPLACE,
+                xid,
+                reply.atom,
+                xproto::AtomEnum::CARDINAL,
+                &[1u32],
+            );
+        }
+    }
+
+    let _ = conn.flush();
+}
+
+fn request_x11_always_on_top(window: &impl IsA<gtk4::Window>) -> Result<(), String> {
+    let surface = window
+        .as_ref()
+        .surface()
+        .ok_or_else(|| "missing GTK surface".to_string())?;
+    let x11_surface = surface
+        .downcast::<X11Surface>()
+        .map_err(|_| "surface is not X11 (compositor does not expose X11 backend)".to_string())?;
+    let xid = u32::try_from(x11_surface.xid())
+        .map_err(|_| "X11 window id is out of range for xproto window type".to_string())?;
+    let (conn, screen_num) = x11rb::connect(None).map_err(|e| e.to_string())?;
+    let root = conn
+        .setup()
+        .roots
+        .get(screen_num)
+        .map(|screen| screen.root)
+        .ok_or_else(|| "missing X11 root window".to_string())?;
+
+    let net_wm_state = intern_atom(&conn, b"_NET_WM_STATE")?;
+    let net_wm_state_above = intern_atom(&conn, b"_NET_WM_STATE_ABOVE")?;
+    let net_wm_state_sticky = intern_atom(&conn, b"_NET_WM_STATE_STICKY")?;
+
+    send_net_wm_state_client_message(&conn, root, xid, net_wm_state, 1, net_wm_state_above, 0)?;
+    send_net_wm_state_client_message(&conn, root, xid, net_wm_state, 1, net_wm_state_sticky, 0)?;
+    conn.configure_window(
+        xid,
+        &xproto::ConfigureWindowAux::new().stack_mode(xproto::StackMode::ABOVE),
+    )
+    .map_err(|e| e.to_string())?;
+    conn.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn position_x11_window(window: &impl IsA<gtk4::Window>, x: i32, y: i32) -> Result<(), String> {
+    let surface = window
+        .as_ref()
+        .surface()
+        .ok_or_else(|| "missing GTK surface".to_string())?;
+    let x11_surface = surface
+        .downcast::<X11Surface>()
+        .map_err(|_| "surface is not X11 (compositor does not expose X11 backend)".to_string())?;
+    let xid = u32::try_from(x11_surface.xid())
+        .map_err(|_| "X11 window id is out of range for xproto window type".to_string())?;
+    let (conn, _) = x11rb::connect(None).map_err(|e| e.to_string())?;
+    conn.configure_window(
+        xid,
+        &xproto::ConfigureWindowAux::new()
+            .x(x)
+            .y(y)
+            .stack_mode(xproto::StackMode::ABOVE),
+    )
+    .map_err(|e| e.to_string())?;
+    conn.flush().map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn intern_atom<C: Connection>(conn: &C, atom_name: &[u8]) -> Result<u32, String> {
+    conn.intern_atom(false, atom_name)
+        .map_err(|e| e.to_string())?
+        .reply()
+        .map_err(|e| e.to_string())
+        .map(|reply| reply.atom)
+}
+
+fn send_net_wm_state_client_message<C: Connection>(
+    conn: &C,
+    root: xproto::Window,
+    window: xproto::Window,
+    net_wm_state_atom: u32,
+    action: u32,
+    first_property: u32,
+    second_property: u32,
+) -> Result<(), String> {
+    let client_message = xproto::ClientMessageEvent::new(
+        32,
+        window,
+        net_wm_state_atom,
+        [action, first_property, second_property, 1, 0],
+    );
+
+    conn.send_event(
+        false,
+        root,
+        xproto::EventMask::SUBSTRUCTURE_REDIRECT | xproto::EventMask::SUBSTRUCTURE_NOTIFY,
+        client_message,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(())
 }


### PR DESCRIPTION
This PR replaces the basic "Stop" overlay with a floating GTK4 controls bar that appears during screen recording, exposing Stop, Pause (disabled), Restart (disabled), Discard, and Menu buttons, plus an optional elapsed timer and drag-to-reposition.

### C++ Overlay
- **`CaptureOverlay.h`**: Added `recordFullscreen()` accessor.
- **`main.cpp`**: Updated `printRecordingJson()` to emit `"fullscreen"` and added the flag to the recording JSON call site.

### Rust Overlay Bridge
- **`src/capture_overlay.rs`**: Added `fullscreen` field to `RecordingRequest` and parse logic for the new JSON key.

### Recording Controls Module
- **` src/recording/stop_overlay.rs`**: Complete rewrite.
  - Introduced `StopAction` enum (`Save`/`Discard`) and `RecordingControlsParams` struct.
  - Implemented `run_recording_controls()` with capture-aware positioning (top center for fullscreen; anchored below/above capture area otherwise).
  - Added GTK4 layer-shell integration for Wayland (Top layer with margin-based positioning) and X11 fallback (`_NET_WM_WINDOW_TYPE_NOTIFICATION`, `_NET_WM_STATE_ABOVE`).
  - Cairo-drawn stop (red circle outline + filled square) and pause (white circle outline + bars) icon buttons.
  - Added elapsed timer driven by `glib::timeout_add_local`.
  - Pause and Restart buttons are present but disabled.
  - Discard button sends `StopAction::Discard`; Stop/ESC sends `StopAction::Save`.
  - Implemented drag-to-reposition via `GestureDrag` updating layer-shell margins or X11 window position.
  - Kept `run_recording_stop_overlay()` for backward compatibility (defaults to fullscreen/timer off).

### Recording Pipeline Integration
- **`src/recording/mod.rs`**: Exported new types and updated `start_recording_with_stop()` and `start_recording_with_optional_stop()` to accept `Receiver<StopAction>` and return `(PathBuf, StopAction)`. Both GIF and video paths now handle the new payload, defaulting to `Save` when the channel is closed/dropped.

### Main CLI / Daemon Wiring
- **`src/main.rs`**: Spawns `run_recording_controls` with capture geometry/fullscreen flags when controls are enabled; handles `Discard` by removing the output file.
- **`src/daemon/mod.rs`**: `handle_record_screen` uses `run_recording_stop_overlay`; `handle_record_area` uses `run_recording_controls` with area coordinates.

<a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/pull/10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open in Capy" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/6bb816f3-c463-4687-84e9-4f612da5b62b/task/fa6b463c-9aac-4d7a-b8e8-b28ae0f7f0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-4&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-4"><img alt="APE-4 · 5.4" src="https://capy.ai/api/badge/task.svg?model=gpt-5.4&task=APE-4"></picture></a>