### PR TITLE
feat: enhance colors panel with improved eyedropper, slider controls, and UI refinements

### DIFF
--- a/docs/superpowers/plans/2026-04-06-right-inspector-colors-management.md
+++ b/docs/superpowers/plans/2026-04-06-right-inspector-colors-management.md
@@ -1,0 +1,65 @@
+# Right Inspector Colors Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the right inspector Colors tab so it manages shared custom colors and eyedropper-driven color capture while leaving the toolbar color picker visually unchanged.
+
+**Architecture:** Reuse the existing toolbar color picker’s persistent custom-color slot model and color-application hooks instead of building a second system. Extend the sidebar Colors panel into a fuller color-management surface with palette colors, current color preview, `My colors`, add/remove actions, and an eyedropper entry point, while both toolbar and sidebar continue to operate on the same underlying data.
+
+**Tech Stack:** Rust 2021, GTK4, existing ApexShot editor color/state/window/ui_support modules
+
+---
+
+## File map
+
+- Modify: `src/capture/editor/window/colors_panel.rs` — expand sidebar Colors panel with shared custom slots, add/remove actions, and eyedropper trigger
+- Modify: `src/capture/editor/window/color_picker.rs` — expose/reuse shared custom-color slot and eyedropper hooks without changing toolbar visuals
+- Modify: `src/capture/editor/window/mod.rs` — pass shared color hooks into the Colors panel
+- Modify: `src/capture/editor/ui_support.rs` — style `My colors`, action buttons, and sidebar custom-slot affordances
+- Test: `src/capture/editor/window/colors_panel.rs` — source regression tests for `My colors`, add/remove, and eyedropper markers
+
+### Task 1: Add failing regression tests for expanded Colors sidebar
+- [ ] Add source tests in `src/capture/editor/window/colors_panel.rs` asserting production source contains `My colors`, `Add current color`, and `Pick from screen` markers.
+- [ ] Add a source test in `src/capture/editor/window/colors_panel.rs` asserting production source contains sidebar custom-slot removal wiring markers.
+- [ ] Run: `cargo test colors_panel_management`
+- [ ] Verify tests fail for the expected missing markers.
+
+### Task 2: Expose shared hooks from the toolbar color picker module
+- [ ] In `src/capture/editor/window/color_picker.rs`, factor or expose the reusable custom-slot persistence/apply helpers needed by the sidebar panel.
+- [ ] Expose an eyedropper trigger hook that the sidebar can call without changing toolbar visuals.
+- [ ] Keep the toolbar picker UI unchanged.
+- [ ] Run: `cargo build`
+
+### Task 3: Expand the sidebar Colors panel with shared color management
+- [ ] In `src/capture/editor/window/colors_panel.rs`, add `My colors` backed by the same persisted custom slots used by the toolbar picker.
+- [ ] Add an `Add current color` action that stores the current color into the first available slot.
+- [ ] Add removal buttons per custom slot that clear only that saved slot.
+- [ ] Add a `Pick from screen` button wired to the shared eyedropper trigger.
+- [ ] Keep the hex display read-only for this pass.
+- [ ] Run: `cargo test colors_panel_management`
+- [ ] Verify tests pass.
+
+### Task 4: Wire the expanded Colors panel into the editor window
+- [ ] In `src/capture/editor/window/mod.rs`, pass the shared apply/sync/custom-slot/eyedropper hooks into `colors_panel::build_colors_panel`.
+- [ ] Ensure toolbar picker and sidebar panel both operate on the same saved custom colors.
+- [ ] Keep existing inspector tab behavior intact.
+- [ ] Run: `cargo build`
+
+### Task 5: Style the sidebar color-management surface
+- [ ] In `src/capture/editor/ui_support.rs`, add CSS for:
+  - `My colors` section
+  - add/remove action buttons
+  - sidebar custom slot layout
+  - read-only hex/current color preview affordances
+- [ ] Keep the styling aligned with the current inspector visual language.
+- [ ] Run: `cargo build`
+
+### Task 6: Final verification
+- [ ] Run: `cargo build && cargo test colors_panel_management`
+- [ ] Manually verify in a desktop session with `cargo run -- edit <image-path>`:
+  - Colors tab shows `My colors`
+  - `Add current color` saves into the shared custom list
+  - removing a saved color clears only that slot
+  - `Pick from screen` updates current color
+  - toolbar color picker remains visually unchanged
+  - toolbar and sidebar reflect the same saved custom colors

--- a/docs/superpowers/plans/2026-04-06-right-inspector-colors-tab.md
+++ b/docs/superpowers/plans/2026-04-06-right-inspector-colors-tab.md
@@ -1,0 +1,63 @@
+# Right Inspector Colors Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a tool-aware Colors tab to the annotate editor right inspector while keeping the existing toolbar color picker untouched.
+
+**Architecture:** Convert the right inspector into a small tabbed shell with reusable panel widgets for Background, Colors, and Placeholder content. Keep Background as its own reusable panel, add a new Colors panel module that can read and update editor color state, and extend inspector/tool routing so Background shows `Background | Colors` while color-capable tools show `Colors` only.
+
+**Tech Stack:** Rust 2021, GTK4, existing ApexShot editor window/state/toolbar/ui_support modules
+
+---
+
+## File map
+
+- Modify: `src/capture/editor/window/mod.rs` — inspector shell, tabs, panel stack, tool-driven inspector state wiring
+- Modify: `src/capture/editor/window/toolbar.rs` — color-tool classification and inspector routing hooks
+- Modify: `src/capture/editor/window/background_panel.rs` — keep reusable as Background tab content
+- Create: `src/capture/editor/window/colors_panel.rs` — reusable shared Colors inspector panel
+- Modify: `src/capture/editor/ui_support.rs` — inspector tabs and colors-panel styling
+- Test: `src/capture/editor/window/mod.rs` — source regression tests for tab shell and colors inspector wiring
+- Test: `src/capture/editor/window/toolbar.rs` — source regression test for color-tool routing markers
+
+### Task 1: Add failing regression tests for inspector tabs and colors panel wiring
+- [ ] Add source tests in `src/capture/editor/window/mod.rs` asserting production source contains `editor-inspector-tabs`, `colors_inspector`, and `Background | Colors` / `Colors` routing markers.
+- [ ] Add a source test in `src/capture/editor/window/toolbar.rs` asserting production source contains a color-tool classifier branch.
+- [ ] Run: `cargo test inspector_tabs colors_tool`
+- [ ] Verify tests fail for the expected missing markers.
+
+### Task 2: Create reusable Colors inspector panel
+- [ ] Create `src/capture/editor/window/colors_panel.rs` with a reusable `ColorsPanelParts { root: GtkBox }` builder.
+- [ ] Build a prototype panel containing a title, helper copy, selected color preview, and shared swatch grid based on the existing editor palette concept.
+- [ ] Wire swatch clicks to existing editor color state only; do not remove or alter the toolbar color picker UI.
+- [ ] Run a targeted build: `cargo build`
+
+### Task 3: Convert the right inspector into a tabbed shell
+- [ ] In `src/capture/editor/window/mod.rs`, replace the single-content inspector with a shell that contains a tab/header row and a content stack.
+- [ ] Mount reusable `background_inspector`, `colors_inspector`, and `placeholder_inspector` panels into that shell.
+- [ ] Add tab buttons for `Background` and `Colors`, and keep placeholder content for non-supported tools.
+- [ ] Run: `cargo test inspector_tabs`
+- [ ] Verify new tests pass.
+
+### Task 4: Route tools into the new inspector behavior
+- [ ] In `src/capture/editor/window/toolbar.rs`, classify color-capable tools: `Pen`, `Arrow`, `Line`, `Box`, `Circle`, `Text`, `Number`, `Highlighter`, `Obfuscate`, `Focus`.
+- [ ] Update the tool updater closure so:
+  - Background shows tabs `Background | Colors` and defaults to Background
+  - color-capable tools show `Colors`
+  - Select/Crop keep placeholder content
+- [ ] Preserve current toolbar color picker behavior unchanged.
+- [ ] Run: `cargo test colors_tool && cargo build`
+
+### Task 5: Style the tabbed inspector
+- [ ] In `src/capture/editor/ui_support.rs`, add CSS classes for inspector tabs, active tab state, colors panel sections, swatches, and preview.
+- [ ] Keep the visual style aligned with the existing dark inspector language.
+- [ ] Run: `cargo build`
+
+### Task 6: Final verification
+- [ ] Run: `cargo build && cargo test inspector_tabs colors_tool`
+- [ ] Manually verify in a desktop session with `cargo run -- edit <image-path>`:
+  - Background shows `Background | Colors`
+  - color-capable tools show `Colors`
+  - Select/Crop still show placeholder
+  - toolbar color picker remains present and untouched
+  - colors sidebar swatches update editor color state

--- a/docs/superpowers/plans/2026-04-07-right-inspector-shared-colors-tab.md
+++ b/docs/superpowers/plans/2026-04-07-right-inspector-shared-colors-tab.md
@@ -1,0 +1,426 @@
+# Right Inspector Shared Colors Tab Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Background's embedded plain-color controls and route both Background and color-capable tools through one shared right-inspector Colors tab backed by the existing picker state.
+
+**Architecture:** Keep `background_panel.rs` focused on Background-specific layout/styling controls, and make the inspector shell route Background to `Background | Colors` while color-capable tools render `Colors` directly. Reuse the existing toolbar color-picker hooks, palette, custom slots, and eyedropper behavior so the toolbar and sidebar stay synchronized instead of creating a second color system.
+
+**Tech Stack:** Rust 2021, GTK4, existing ApexShot editor window/state/color/color-picker modules
+
+---
+
+## File map
+
+- Modify: `src/capture/editor/window/background_panel.rs` — remove embedded `Plain color` UI and add source regression tests for the new Background panel structure
+- Modify: `src/capture/editor/window/colors_panel.rs` — expand or adapt the shared Colors inspector so it can apply colors to Background as well as annotation tools
+- Modify: `src/capture/editor/window/color_picker.rs` — expose shared color-application/custom-slot/eyedropper hooks needed by the inspector panel without changing toolbar visuals
+- Modify: `src/capture/editor/window/mod.rs` — wire inspector tab state, mount shared Colors content, and route Background plus color-capable tools
+- Modify: `src/capture/editor/window/toolbar.rs` — update tool classification/routing logic for Background and color-capable tools
+- Modify: `src/capture/editor/ui_support.rs` — add or adjust inspector styling for the shared Colors surface and remove obsolete Background plain-color styling if it becomes unused
+- Test: `src/capture/editor/window/background_panel.rs` — source regression tests for Background plain-color removal
+- Test: `src/capture/editor/window/colors_panel.rs` — source regression tests for shared Colors tab markers and Background-specific apply wiring
+- Test: `src/capture/editor/window/mod.rs` or `src/capture/editor/window/toolbar.rs` — source regression tests for inspector routing behavior
+
+### Task 1: Add failing regression tests for shared Colors routing and Background plain-color removal
+
+**Files:**
+- Modify: `src/capture/editor/window/background_panel.rs`
+- Modify: `src/capture/editor/window/colors_panel.rs`
+- Modify: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Add a failing source test for Background plain-color removal**
+
+```rust
+#[test]
+fn background_panel_no_longer_appends_plain_color_section() {
+    let source = include_str!("background_panel.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        !production_source.contains("plain_color_section.append(&plain_color_title);")
+            && !production_source.contains("background_sidebar_options.append(&plain_color_section);"),
+        "Background panel should no longer render the embedded plain-color section",
+    );
+}
+```
+
+- [ ] **Step 2: Add a failing source test for shared Colors panel Background apply markers**
+
+```rust
+#[test]
+fn colors_panel_contains_background_plain_color_apply_markers() {
+    let source = include_str!("colors_panel.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("BackgroundStyle::PlainColor")
+            && production_source.contains("selected_tool == Tool::Background"),
+        "Colors panel should support applying plain colors for the Background tool",
+    );
+}
+```
+
+- [ ] **Step 3: Add a failing source test for inspector routing**
+
+```rust
+#[test]
+fn background_and_color_tools_route_into_shared_colors_inspector() {
+    let source = include_str!("toolbar.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("Tool::Background")
+            && production_source.contains("Tool::Pen")
+            && production_source.contains("Tool::Highlighter")
+            && production_source.contains("\"Colors\""),
+        "Toolbar inspector routing should include Background and color-capable tools in the shared Colors flow",
+    );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test background_panel_no_longer_appends_plain_color_section -- --nocapture
+cargo test colors_panel_contains_background_plain_color_apply_markers -- --nocapture
+cargo test background_and_color_tools_route_into_shared_colors_inspector -- --nocapture
+```
+
+Expected: all three tests fail because the Background panel still contains `Plain color`, the Colors panel is not yet wired for Background, and the routing source markers are incomplete.
+
+- [ ] **Step 5: Commit the failing tests**
+
+```bash
+git add src/capture/editor/window/background_panel.rs src/capture/editor/window/colors_panel.rs src/capture/editor/window/toolbar.rs
+git commit -m "test: cover shared colors inspector routing"
+```
+
+### Task 2: Expose reusable color-management hooks from the toolbar picker path
+
+**Files:**
+- Modify: `src/capture/editor/window/color_picker.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/color_picker.rs`
+
+- [ ] **Step 1: Identify or extract the shared apply/custom-slot helpers from the toolbar picker**
+
+```rust
+pub(super) struct SharedColorHooks {
+    pub apply_annotation_color: Rc<dyn Fn(DrawColor)>,
+    pub apply_background_color: Rc<dyn Fn(DrawColor)>,
+    pub load_custom_colors: Rc<dyn Fn() -> PersistedCustomColorSlots>,
+    pub save_custom_colors: Rc<dyn Fn(PersistedCustomColorSlots)>,
+    pub launch_eyedropper: Rc<dyn Fn()>,
+}
+```
+
+- [ ] **Step 2: Wire the Background apply hook to `BackgroundStyle::PlainColor` in editor state**
+
+```rust
+let apply_background_color: Rc<dyn Fn(DrawColor)> = Rc::new({
+    let state = state.clone();
+    let drawing_area = drawing_area.clone();
+    move |color| {
+        let mut st = state.lock().unwrap();
+        st.background_style = BackgroundStyle::PlainColor(color);
+        st.mark_working_image_dirty();
+        drawing_area.queue_draw();
+    }
+});
+```
+
+- [ ] **Step 3: Keep toolbar visuals untouched while exporting these hooks for sidebar use**
+
+```rust
+// Reuse the same persistence/apply functions for both toolbar and sidebar surfaces.
+let shared_color_hooks = SharedColorHooks {
+    apply_annotation_color,
+    apply_background_color,
+    load_custom_colors,
+    save_custom_colors,
+    launch_eyedropper,
+};
+```
+
+- [ ] **Step 4: Run targeted build to verify the hook extraction compiles**
+
+Run:
+
+```bash
+cargo build
+```
+
+Expected: build succeeds with the toolbar picker still compiling unchanged.
+
+- [ ] **Step 5: Commit the hook extraction**
+
+```bash
+git add src/capture/editor/window/color_picker.rs src/capture/editor/window/mod.rs
+git commit -m "refactor: share editor color hooks with inspector"
+```
+
+### Task 3: Expand the Colors panel so it can drive Background and annotation tools
+
+**Files:**
+- Modify: `src/capture/editor/window/colors_panel.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/colors_panel.rs`
+
+- [ ] **Step 1: Update the Colors panel builder API to accept shared hooks and tool context**
+
+```rust
+pub(super) fn build_colors_panel(
+    selected_tool: Tool,
+    shared_hooks: SharedColorHooks,
+) -> ColorsPanelParts
+```
+
+- [ ] **Step 2: Route palette/custom-color selection through Background or annotation apply logic**
+
+```rust
+let apply_selected_color = {
+    let shared_hooks = shared_hooks.clone();
+    move |color: DrawColor| {
+        if selected_tool == Tool::Background {
+            (shared_hooks.apply_background_color)(color);
+        } else {
+            (shared_hooks.apply_annotation_color)(color);
+        }
+    }
+};
+```
+
+- [ ] **Step 3: Keep shared custom colors and eyedropper behavior intact**
+
+```rust
+let saved_slots = (shared_hooks.load_custom_colors)();
+// build shared swatches from `saved_slots`
+
+pick_from_screen_button.connect_clicked({
+    let shared_hooks = shared_hooks.clone();
+    move |_| (shared_hooks.launch_eyedropper)()
+});
+```
+
+- [ ] **Step 4: Run the Colors panel tests**
+
+Run:
+
+```bash
+cargo test colors_panel_contains_background_plain_color_apply_markers -- --nocapture
+```
+
+Expected: PASS once the Background apply markers and shared hook usage exist in `colors_panel.rs`.
+
+- [ ] **Step 5: Commit the shared Colors panel behavior**
+
+```bash
+git add src/capture/editor/window/colors_panel.rs src/capture/editor/window/mod.rs
+git commit -m "feat: share colors inspector across background and tools"
+```
+
+### Task 4: Remove Background plain-color UI and keep only Background-specific controls
+
+**Files:**
+- Modify: `src/capture/editor/window/background_panel.rs`
+- Test: `src/capture/editor/window/background_panel.rs`
+
+- [ ] **Step 1: Delete the embedded `Plain color` section from `background_panel.rs`**
+
+```rust
+// Remove:
+// let plain_color_section = GtkBox::new(...)
+// let plain_color_title = Label::new(Some("Plain color"));
+// let plain_color_grid = GtkBox::new(...)
+// background_sidebar_options.append(&plain_color_section);
+```
+
+- [ ] **Step 2: Keep the Background stack limited to Background-specific controls**
+
+```rust
+background_sidebar_options.append(&background_none_btn);
+background_sidebar_options.append(&alignment_section);
+background_sidebar_options.append(&gradients_section);
+background_sidebar_options.append(&wallpaper_section);
+background_sidebar_options.append(&blurred_section);
+background_sidebar_options.append(&background_padding_divider_row);
+background_sidebar_options.append(&padding_section);
+background_sidebar_options.append(&ratio_section);
+background_sidebar_options.append(&compact_controls);
+```
+
+- [ ] **Step 3: Run the Background panel regression test**
+
+Run:
+
+```bash
+cargo test background_panel_no_longer_appends_plain_color_section -- --nocapture
+```
+
+Expected: PASS after the plain-color section and append markers are removed.
+
+- [ ] **Step 4: Commit the Background panel cleanup**
+
+```bash
+git add src/capture/editor/window/background_panel.rs
+git commit -m "refactor: remove background plain color section"
+```
+
+### Task 5: Route Background and color-capable tools into the shared Colors inspector behavior
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/window/toolbar.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Classify Background and all color-capable tools for inspector routing**
+
+```rust
+fn tool_supports_colors(tool: Tool) -> bool {
+    matches!(
+        tool,
+        Tool::Background
+            | Tool::Pen
+            | Tool::Arrow
+            | Tool::Line
+            | Tool::Box
+            | Tool::Circle
+            | Tool::Text
+            | Tool::Number
+            | Tool::Highlighter
+            | Tool::Obfuscate
+            | Tool::Focus
+    )
+}
+```
+
+- [ ] **Step 2: Route Background to `Background | Colors` and default it to `Background`**
+
+```rust
+if selected_tool == Tool::Background {
+    inspector_tabs.set_tabs(["Background", "Colors"]);
+    inspector_tabs.set_active("Background");
+}
+```
+
+- [ ] **Step 3: Route color-capable annotation tools to `Colors` only**
+
+```rust
+else if tool_supports_colors(selected_tool) {
+    inspector_tabs.set_tabs(["Colors"]);
+    inspector_tabs.set_active("Colors");
+}
+```
+
+- [ ] **Step 4: Run the routing regression test**
+
+Run:
+
+```bash
+cargo test background_and_color_tools_route_into_shared_colors_inspector -- --nocapture
+```
+
+Expected: PASS once Background and the color-capable tool list are part of the shared Colors routing flow.
+
+- [ ] **Step 5: Commit the inspector routing changes**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/toolbar.rs
+git commit -m "feat: route background and color tools through colors inspector"
+```
+
+### Task 6: Update inspector styling and remove obsolete Background plain-color styling
+
+**Files:**
+- Modify: `src/capture/editor/ui_support.rs`
+- Test: `src/capture/editor/ui_support.rs`
+
+- [ ] **Step 1: Remove or stop relying on obsolete Background plain-color style markers if they become unused**
+
+```rust
+// Remove unused selectors such as:
+// .editor-background-plain-color-section
+// .editor-background-plain-color-grid
+// .editor-background-plain-color-row
+```
+
+- [ ] **Step 2: Add or keep shared Colors panel styling aligned with the inspector surface**
+
+```rust
+            .editor-colors-panel {
+                margin-top: 4px;
+            }
+
+            .editor-colors-panel-section-title {
+                color: #f5f5f7;
+                font-size: 14px;
+                font-weight: 700;
+            }
+```
+
+- [ ] **Step 3: Run a targeted build to verify CSS/source tests remain valid**
+
+Run:
+
+```bash
+cargo build
+```
+
+Expected: build succeeds without stale style references breaking the editor module.
+
+- [ ] **Step 4: Commit the style cleanup**
+
+```bash
+git add src/capture/editor/ui_support.rs
+git commit -m "style: align shared colors inspector with sidebar"
+```
+
+### Task 7: Final verification
+
+**Files:**
+- Modify: none
+
+- [ ] **Step 1: Run the focused inspector/background/colors test slice**
+
+Run:
+
+```bash
+cargo test background_panel::tests:: -- --nocapture
+cargo test colors_panel -- --nocapture
+cargo test editor_background_alignment_ -- --nocapture
+```
+
+Expected: PASS for the Background panel ordering/removal tests, Colors panel tests, and the existing alignment CSS checks.
+
+- [ ] **Step 2: Run a full build**
+
+Run:
+
+```bash
+cargo build
+```
+
+Expected: successful build with no compile errors.
+
+- [ ] **Step 3: Manually verify the editor in a desktop session**
+
+Run:
+
+```bash
+cargo run -- edit <image-path>
+```
+
+Expected:
+- Background tool shows `Background | Colors`
+- Background tab no longer shows `Plain color`
+- Colors tab can set a solid background color
+- switching between toolbar picker and sidebar keeps colors synchronized
+- color-capable annotation tools show the shared Colors panel
+- non-color tools do not incorrectly show the Colors panel
+
+- [ ] **Step 4: Commit the verification checkpoint**
+
+```bash
+git add docs/superpowers/plans/2026-04-07-right-inspector-shared-colors-tab.md
+git commit -m "docs: add shared colors inspector implementation plan"
+```

--- a/docs/superpowers/plans/2026-04-07-toolbar-color-status-and-right-panel-colors.md
+++ b/docs/superpowers/plans/2026-04-07-toolbar-color-status-and-right-panel-colors.md
@@ -1,0 +1,443 @@
+# Toolbar Color Status And Right Panel Colors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the toolbar color picker with a passive swatch-plus-hex status chip, move all color editing into the right `Colors` tab, and remove duplicated current-color UI from the right panel.
+
+**Architecture:** Keep editor color state as the single source of truth. The toolbar becomes a read-only projection of the active tool color, while the right `Colors` tab remains the only editing surface and is auto-selected when a color-capable tool is chosen.
+
+**Tech Stack:** Rust, GTK4, existing editor state/sync closures, existing right-inspector colors panel, existing toolbar mode controls.
+
+---
+
+### Task 1: Replace Toolbar Picker With Read-Only Status Chip
+
+**Files:**
+- Modify: `src/capture/editor/window/color_picker.rs`
+- Modify: `src/capture/editor/window/toolbar.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Write the failing toolbar source test**
+
+```rust
+#[test]
+fn toolbar_uses_read_only_color_status_chip_instead_of_picker_trigger() {
+    let source = include_str!("toolbar.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("editor-toolbar-color-status")
+            && production_source.contains("editor-toolbar-color-status-swatch")
+            && production_source.contains("editor-toolbar-color-status-label")
+            && !production_source.contains("color_picker_trigger_host"),
+        "Toolbar should use a read-only color status chip instead of the picker trigger host",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test toolbar_uses_read_only_color_status_chip_instead_of_picker_trigger -- --nocapture`
+Expected: FAIL because the toolbar still appends `color_picker_trigger_host`.
+
+- [ ] **Step 3: Write the minimal toolbar status implementation**
+
+```rust
+let color_status = GtkBox::new(Orientation::Horizontal, 8);
+color_status.add_css_class("editor-toolbar-color-status");
+
+let color_status_swatch = GtkBox::new(Orientation::Horizontal, 0);
+color_status_swatch.add_css_class("editor-toolbar-color-status-swatch");
+color_status_swatch.set_widget_name("editor-toolbar-color-status-swatch");
+
+let color_status_label = Label::new(Some("#121212"));
+color_status_label.add_css_class("editor-toolbar-color-status-label");
+color_status_label.set_xalign(0.0);
+
+color_status.append(&color_status_swatch);
+color_status.append(&color_status_label);
+```
+
+```rust
+pub struct ToolbarModeParts {
+    pub root: GtkBox,
+    pub toolbar_mode_stack: Stack,
+    pub color_status_swatch: GtkBox,
+    pub color_status_label: Label,
+    // keep existing fields unchanged
+}
+```
+
+```rust
+pub(super) fn build_toolbar_mode_controls(
+    /* existing args minus color_picker_trigger_host */
+) -> ToolbarModeParts {
+    let color_group = GtkBox::new(Orientation::Horizontal, 0);
+    color_group.add_css_class("editor-color-group");
+    color_group.append(&color_status);
+    // keep the rest of the toolbar construction unchanged
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test toolbar_uses_read_only_color_status_chip_instead_of_picker_trigger -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/window/color_picker.rs src/capture/editor/window/toolbar.rs src/capture/editor/window/mod.rs
+git commit -m "refactor: replace toolbar color picker with status chip"
+```
+
+### Task 2: Sync Toolbar Status Chip From Shared Color State
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/window/color_picker.rs`
+- Test: `src/capture/editor/window/mod.rs`
+
+- [ ] **Step 1: Write the failing sync source test**
+
+```rust
+#[test]
+fn toolbar_color_status_syncs_from_shared_active_color() {
+    let source = include_str!("mod.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("editor-toolbar-color-status-swatch")
+            && production_source.contains("color_status_label.set_label")
+            && production_source.contains("BackgroundStyle::PlainColor")
+            && production_source.contains("draw_color_to_hex(active_color)"),
+        "Toolbar color status should mirror the shared active color, including Background plain color",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test toolbar_color_status_syncs_from_shared_active_color -- --nocapture`
+Expected: FAIL because no shared status-chip sync exists yet.
+
+- [ ] **Step 3: Write the minimal sync closure**
+
+```rust
+let sync_toolbar_color_status: Rc<dyn Fn()> = Rc::new({
+    let state = state.clone();
+    let color_status_swatch = color_status_swatch.clone();
+    let color_status_label = color_status_label.clone();
+    move || {
+        let active_color = {
+            let st = state.lock().unwrap();
+            if st.selected_tool == Tool::Background {
+                if let BackgroundStyle::PlainColor(color) = st.background_style {
+                    color
+                } else {
+                    st.selected_color
+                }
+            } else {
+                st.selected_color
+            }
+        };
+
+        color_status_label.set_label(&format!("#{}", draw_color_to_hex(active_color)));
+        let (r, g, b, _) = draw_color_to_rgba_u8(active_color);
+        let alpha = active_color.a.clamp(0.0, 1.0);
+        let css = format!(
+            "#editor-toolbar-color-status-swatch {{ background: rgba({r}, {g}, {b}, {alpha:.3}); }}"
+        );
+        toolbar_color_css_provider.load_from_data(&css);
+    }
+});
+```
+
+```rust
+let sync_shared_colors_for_active_tool: Rc<dyn Fn()> = Rc::new({
+    let sync_toolbar_color_status = sync_toolbar_color_status.clone();
+    let sync_picker_for_active_tool = sync_picker_for_active_tool.clone();
+    let sync_colors_panel_for_active_tool = sync_colors_panel_for_active_tool.clone();
+    move || {
+        sync_toolbar_color_status();
+        sync_picker_for_active_tool();
+        sync_colors_panel_for_active_tool();
+    }
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test toolbar_color_status_syncs_from_shared_active_color -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/color_picker.rs
+git commit -m "feat: sync toolbar color status from shared editor color"
+```
+
+### Task 3: Auto-Route Color Tools Into The Right Colors Tab
+
+**Files:**
+- Modify: `src/capture/editor/window/toolbar.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Write the failing routing test**
+
+```rust
+#[test]
+fn color_capable_tools_default_to_colors_inspector_surface() {
+    let source = include_str!("toolbar.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("set_active_inspector_surface(\"colors\")")
+            && production_source.contains("Tool::Background")
+            && production_source.contains("Tool::Pen")
+            && production_source.contains("Tool::Focus"),
+        "Color-capable tools should switch the right inspector to the Colors surface",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test color_capable_tools_default_to_colors_inspector_surface -- --nocapture`
+Expected: FAIL because tool routing still defaults `Background` to the background inspector.
+
+- [ ] **Step 3: Write the minimal routing change**
+
+```rust
+if matches!(
+    tool,
+    Tool::Background
+        | Tool::Pen
+        | Tool::Arrow
+        | Tool::Line
+        | Tool::Box
+        | Tool::Circle
+        | Tool::Text
+        | Tool::Number
+        | Tool::Highlighter
+        | Tool::Obfuscate
+        | Tool::Focus
+) {
+    sync_colors_panel_for_active_tool();
+    set_active_inspector_surface("colors");
+}
+```
+
+```rust
+background_tab_btn.set_visible(matches!(tool, Tool::Background));
+colors_tab_btn.set_visible(colors_mode);
+background_inspector.set_visible(false);
+colors_inspector.set_visible(colors_mode);
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test color_capable_tools_default_to_colors_inspector_surface -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/window/toolbar.rs src/capture/editor/window/mod.rs
+git commit -m "feat: route color tools into colors inspector"
+```
+
+### Task 4: Remove Duplicated Current Color Section From Right Colors Tab
+
+**Files:**
+- Modify: `src/capture/editor/window/colors_panel.rs`
+- Test: `src/capture/editor/window/colors_panel.rs`
+
+- [ ] **Step 1: Write the failing duplication test**
+
+```rust
+#[test]
+fn colors_panel_no_longer_renders_current_color_summary_section() {
+    let source = include_str!("colors_panel.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        !production_source.contains("Current color")
+            && !production_source.contains("editor-colors-panel-current-row")
+            && !production_source.contains("editor-sidebar-current-color-preview"),
+        "Colors panel should not duplicate the current color summary once the toolbar owns that status",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test colors_panel_no_longer_renders_current_color_summary_section -- --nocapture`
+Expected: FAIL because the `Current color` row still exists.
+
+- [ ] **Step 3: Write the minimal panel cleanup**
+
+```rust
+// remove:
+// - current_title
+// - current_row
+// - current_preview
+// - current_value
+// - current_section append
+
+content.append(&helper);
+content.append(&spectrum_section);
+content.append(&palette_section);
+content.append(&custom_section);
+content.append(&actions);
+```
+
+```rust
+// keep sync focused on:
+helper.set_label(/* background-aware copy */);
+set_active_color_button(&palette_buttons, palette_index_for_color(active_color));
+let picker = PickerColorState::from_color(active_color);
+*picker_state.borrow_mut() = picker;
+update_picker_ui(picker);
+refresh_custom_slots();
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test colors_panel_no_longer_renders_current_color_summary_section -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/window/colors_panel.rs
+git commit -m "refactor: remove duplicated current color section"
+```
+
+### Task 5: Style The Toolbar Status Chip And Remove Picker-Only UI Debt
+
+**Files:**
+- Modify: `src/capture/editor/ui_support.rs`
+- Modify: `src/capture/editor/window/color_picker.rs`
+- Test: `src/capture/editor/ui_support.rs`
+
+- [ ] **Step 1: Write the failing style test**
+
+```rust
+#[test]
+fn toolbar_color_status_chip_has_swatch_and_hex_styles() {
+    let source = include_str!("ui_support.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains(".editor-toolbar-color-status {")
+            && production_source.contains(".editor-toolbar-color-status-swatch {")
+            && production_source.contains(".editor-toolbar-color-status-label {"),
+        "Toolbar color status chip should have dedicated swatch and label styles",
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test toolbar_color_status_chip_has_swatch_and_hex_styles -- --nocapture`
+Expected: FAIL because the new status chip styles do not exist yet.
+
+- [ ] **Step 3: Write the minimal styles and cleanup**
+
+```css
+.editor-toolbar-color-status {
+    min-height: 34px;
+    padding: 0 10px;
+    border-radius: 9px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    spacing: 8px;
+}
+
+.editor-toolbar-color-status-swatch {
+    min-width: 16px;
+    min-height: 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.editor-toolbar-color-status-label {
+    color: rgba(245, 245, 247, 0.92);
+    font-size: 12px;
+    font-weight: 700;
+}
+```
+
+```rust
+// remove unused toolbar popover-only exports if the toolbar no longer needs them:
+// - trigger_host
+// - popover
+// - color_picker_dot
+// - color_class_names
+// - set_picker_panel_visibility
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cargo test toolbar_color_status_chip_has_swatch_and_hex_styles -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/ui_support.rs src/capture/editor/window/color_picker.rs
+git commit -m "style: add toolbar color status chip"
+```
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify: `src/capture/editor/window/mod.rs`
+- Verify: `src/capture/editor/window/toolbar.rs`
+- Verify: `src/capture/editor/window/colors_panel.rs`
+- Verify: `src/capture/editor/ui_support.rs`
+
+- [ ] **Step 1: Run focused regression tests**
+
+Run: `cargo test toolbar_color_status_syncs_from_shared_active_color -- --nocapture`
+Expected: PASS
+
+Run: `cargo test color_capable_tools_default_to_colors_inspector_surface -- --nocapture`
+Expected: PASS
+
+Run: `cargo test colors_panel_no_longer_renders_current_color_summary_section -- --nocapture`
+Expected: PASS
+
+Run: `cargo test toolbar_color_status_chip_has_swatch_and_hex_styles -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 2: Run existing shared-colors regressions**
+
+Run: `cargo test colors_panel_contains_shared_color_management_markers -- --nocapture`
+Expected: PASS
+
+Run: `cargo test colors_panel_matches_background_content_width -- --nocapture`
+Expected: PASS
+
+Run: `cargo test background_and_color_tools_route_into_shared_colors_inspector -- --nocapture`
+Expected: PASS
+
+- [ ] **Step 3: Run build verification**
+
+Run: `cargo build`
+Expected: exit code 0
+
+- [ ] **Step 4: Manual UI verification**
+
+Run: `apexshot daemon`
+Expected:
+- toolbar shows a swatch + `#HEX` status chip instead of the color picker
+- selecting a color-capable tool switches the right panel to `Colors`
+- editing color from the right panel updates the toolbar status chip live
+- the right panel no longer shows a duplicated `Current color` summary row
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/toolbar.rs src/capture/editor/window/colors_panel.rs src/capture/editor/ui_support.rs src/capture/editor/window/color_picker.rs
+git commit -m "feat: move color editing fully into right inspector"
+```

--- a/docs/superpowers/specs/2026-04-06-right-inspector-colors-tab-design.md
+++ b/docs/superpowers/specs/2026-04-06-right-inspector-colors-tab-design.md
@@ -1,0 +1,128 @@
+# Right Inspector Colors Tab Design
+
+## Goal
+Add a shared Colors tab to the annotate editor’s right inspector without removing or replacing the existing toolbar color picker. The right sidebar should become tool-aware: Background shows `Background | Colors`, while color-capable annotation tools show `Colors` as their primary inspector content. The Colors tab should also grow into a sidebar-based color management surface that shares the same persistent custom color data used by the toolbar picker.
+
+## Scope
+Phase 1 introduces the inspector tab shell and a reusable Colors panel prototype. The Colors panel should be visible for color-capable tools and remain parallel to the toolbar picker. Select and Crop continue to use placeholder inspector content for now.
+
+Phase 2 expands the Colors tab so it can manage shared custom colors using the same storage/model already used by the toolbar color picker. The toolbar picker stays visually intact for now.
+
+## Tool behavior
+### Background
+- Show tabs: `Background`, `Colors`
+- Default active tab: `Background`
+
+### Color-capable tools
+- Tools: `Pen`, `Arrow`, `Line`, `Box`, `Circle`, `Text`, `Number`, `Highlighter`, `Obfuscate`, `Focus`
+- Show tab/header state for `Colors`
+- Show the shared Colors panel as the inspector content
+
+### Non-color tools
+- Tools: `Select`, `Crop`
+- Keep placeholder inspector content for this phase
+
+## Architecture
+The right inspector becomes a small reusable shell with:
+- a tab/header row
+- a content stack
+- reusable panels for:
+  - `background`
+  - `colors`
+  - `placeholder`
+
+The existing background controls remain in their own reusable builder module and become one tab panel. A new colors panel module is added as a sibling reusable panel.
+
+The Colors panel should share the same persistence and custom-color slot model as the toolbar picker rather than introducing a second saved-color system.
+
+## Colors panel
+The expanded Colors panel should include:
+- title: `Colors`
+- shared palette swatch grid based on the existing toolbar color palette concept
+- current color preview
+- read-only hex display for the active color
+- `My colors` section backed by the same persistent custom color slots used by the toolbar picker
+- `Add current color` action
+- `Pick from screen` / eyedropper trigger
+
+## Interaction model
+The Colors tab should distinguish among three concepts:
+1. **Current color**
+   - visible preview chip
+   - read-only hex text
+2. **Palette**
+   - built-in swatches for quick selection
+3. **My colors**
+   - persistent custom saved colors
+   - clicking a saved color applies it
+   - removing a saved color clears only that slot
+
+### Eyedropper behavior
+- Eyedropper selection updates the current active color first
+- The chosen color is not automatically saved into `My colors`
+- The user explicitly saves it via `Add current color`
+
+### Custom color behavior
+- `Add current color` stores the active color into the first available custom slot using the shared persistent slot data
+- Removing a custom color clears only that saved slot, not the current active editor color
+- Toolbar picker and sidebar Colors tab should reflect the same underlying custom color list
+
+## State model
+Inspector state should separately track:
+- selected tool
+- which inspector tab is active when multiple tabs are available
+
+For Background, default to the Background tab when entering that tool. For color-capable tools, default/show the Colors panel. The implementation should avoid removing current toolbar state flows.
+
+The Colors panel should reuse existing editor hooks for:
+- applying a chosen color to the current tool/editor state
+- syncing current active color from editor state
+- launching the existing eyedropper flow where possible
+
+## File impact
+- `src/capture/editor/window/mod.rs`
+  - build inspector shell with tabs and stack
+  - mount background/colors/placeholder panels
+  - route active tool into inspector state
+  - pass shared color hooks into the Colors panel
+- `src/capture/editor/window/toolbar.rs`
+  - extend tool updater so it can classify color-capable tools and drive inspector shell visibility/state
+- `src/capture/editor/window/background_panel.rs`
+  - keep reusable as background tab content
+- `src/capture/editor/window/colors_panel.rs`
+  - reusable shared colors inspector panel
+  - current color preview
+  - palette section
+  - my colors section
+  - add/remove actions
+  - eyedropper trigger
+- `src/capture/editor/window/color_picker.rs`
+  - share persistence and custom-color helpers rather than duplicating logic
+  - expose or reuse eyedropper/custom-color hooks as needed
+- `src/capture/editor/ui_support.rs`
+  - inspector tab styling and colors-panel styling
+  - custom slot styling in the sidebar context
+
+## Testing
+Add regression-style tests for:
+- inspector tabs/header shell exists
+- colors inspector content exists
+- tool updater recognizes color-capable tools
+- background mode exposes both Background and Colors pathways
+- colors panel contains sidebar markers for `My colors`, add/remove actions, and eyedropper support
+
+## Constraints
+- Do not remove or redesign the toolbar color picker yet
+- Keep the change prototype-safe and incremental
+- Share the existing persistent custom color model/data instead of creating a new one
+- Keep sidebar hex display read-only for this pass
+- Favor reusable inspector panel builders over growing `mod.rs`
+
+## Recommended implementation strategy
+Use a semi-wired prototype with shared color management:
+1. keep the tabbed inspector shell
+2. expand the reusable Colors panel module
+3. reuse the toolbar picker’s custom-color persistence model
+4. add sidebar `My colors`, add/remove actions, and eyedropper entry point
+5. keep toolbar picker visually unchanged
+6. allow both surfaces to operate on the same saved custom colors

--- a/docs/superpowers/specs/2026-04-07-right-inspector-shared-colors-tab-design.md
+++ b/docs/superpowers/specs/2026-04-07-right-inspector-shared-colors-tab-design.md
@@ -1,0 +1,165 @@
+# Right Inspector Shared Colors Tab Design
+
+## Goal
+Replace the Background panel's embedded `Plain color` section with a shared right-inspector `Colors` tab that works for both Background and all color-capable annotation tools. The right inspector should become the single sidebar surface for color management while the existing toolbar picker continues to use the same underlying state and persistence model.
+
+## Scope
+This change covers the annotate editor right inspector only.
+
+Included:
+- remove `Plain color` from the Background tab
+- keep `Background | Colors` tabs for the Background tool
+- show `Colors` as the primary inspector content for color-capable tools
+- reuse the existing toolbar color picker logic, palette, custom colors, and eyedropper flow
+- apply chosen colors to Background as `BackgroundStyle::PlainColor(...)`
+- keep toolbar and inspector colors in sync through shared editor state
+
+Not included:
+- replacing or deleting the toolbar color picker UI
+- adding new color models beyond what the current picker already supports
+- redesigning non-color tool inspector content
+
+## Tool Behavior
+
+### Background
+When the selected tool is `Background`, the inspector shows two tabs:
+- `Background`
+- `Colors`
+
+The `Background` tab contains only background-layout and background-style controls:
+- `None`
+- `Alignment`
+- gradients
+- wallpaper
+- blurred
+- `Padding`
+- `Ratio`
+- insert / auto-balance / shadow / corners
+
+The `Plain color` section is removed from this tab.
+
+The `Colors` tab becomes the only place where a solid background color is chosen. Selecting a color there sets the background style to `BackgroundStyle::PlainColor(selected_color)`.
+
+Default tab behavior:
+- entering the Background tool opens the `Background` tab
+- if the user switches to `Colors`, that tab remains active until tool routing changes it
+
+### Color-Capable Tools
+The following tools should show the shared `Colors` inspector content:
+- `Pen`
+- `Arrow`
+- `Line`
+- `Box`
+- `Circle`
+- `Text`
+- `Number`
+- `Highlighter`
+- `Obfuscate`
+- `Focus`
+
+For these tools, the inspector shows `Colors` as the primary panel. Choosing a color updates the same editor color state that the toolbar picker already controls.
+
+### Non-Color Tools
+Non-color tools keep their current placeholder or tool-specific inspector behavior. This change does not expand the Colors tab to tools that do not consume color state.
+
+## Architecture
+The right inspector should use one reusable Colors panel module instead of duplicating color UIs inside each tool panel.
+
+Core structure:
+- `background_panel.rs` owns only Background-specific controls
+- `colors_panel.rs` owns the shared sidebar color-management surface
+- inspector shell / routing decides which tab or panel to show for the selected tool
+- toolbar color picker and sidebar Colors panel both call into the same editor-state update hooks
+
+The Colors panel should be wired against existing shared pieces where possible:
+- current active color state
+- saved custom color slots
+- palette swatches
+- eyedropper flow
+- color application callbacks
+
+Background should use the same Colors panel with a Background-specific apply callback. Annotation tools should use the same panel with the existing draw-color apply callback.
+
+## Interaction Model
+
+### Shared Colors Surface
+The Colors panel should mirror the current picker's capabilities rather than introducing a second color model. At minimum it should support:
+- showing the active color
+- choosing from the existing palette
+- showing saved custom colors
+- adding the current color to custom colors
+- removing a saved custom color
+- launching the existing eyedropper path
+
+The sidebar does not need to visually match the toolbar popover exactly, but it must operate on the same underlying data and produce the same results.
+
+### Background Color Selection
+When Background is active and the user chooses a color in the Colors tab:
+- the selected color becomes the active sidebar color
+- background style switches to `BackgroundStyle::PlainColor(selected_color)`
+- the canvas redraws immediately
+
+If the background is currently a gradient, wallpaper, blur, or `None`, choosing a solid color in `Colors` replaces that style with `PlainColor`.
+
+### Annotation Color Selection
+When a color-capable annotation tool is active and the user chooses a color in `Colors`, the chosen color updates the same tool/editor color state used by the toolbar picker. Existing tool-specific behavior for stroke/fill semantics remains unchanged.
+
+### Sync Rules
+Toolbar picker and inspector Colors tab must stay synchronized:
+- changing color in the toolbar updates the inspector
+- changing color in the inspector updates the toolbar
+- adding/removing custom colors from either surface updates the other
+
+## State Model
+Inspector state should explicitly track:
+- selected tool
+- active inspector tab for tools with multiple tabs
+
+Editor color state remains the source of truth for:
+- current active annotation color
+- saved custom colors
+- background plain color when Background is using `PlainColor`
+
+Background does not need a separate independent color-management model. It only needs a way to map shared color selection actions to `BackgroundStyle::PlainColor(...)`.
+
+## File Impact
+Expected implementation areas:
+- `src/capture/editor/window/background_panel.rs`
+  Remove embedded `Plain color` UI and keep only Background-specific controls.
+- `src/capture/editor/window/colors_panel.rs`
+  Add or expand the reusable shared Colors inspector surface.
+- `src/capture/editor/window/mod.rs`
+  Extend inspector shell state and panel mounting for shared Colors behavior.
+- `src/capture/editor/window/toolbar.rs`
+  Route Background to `Background | Colors` and route color-capable tools to `Colors`.
+- `src/capture/editor/window/color_picker.rs`
+  Expose reusable hooks/helpers needed by the sidebar Colors panel.
+- `src/capture/editor/ui_support.rs`
+  Add styling for the shared Colors inspector surface.
+
+## Testing
+Add regression coverage for:
+- Background inspector no longer rendering `Plain color`
+- Background routing showing `Background | Colors`
+- color-capable tools routing to `Colors`
+- shared color panel using the existing persistence/state model
+- Background color selection switching style to `PlainColor`
+- toolbar and inspector color synchronization where testable at source level
+
+Targeted verification should include:
+- `cargo test` filters for inspector/colors/background modules
+- `cargo build`
+
+## Constraints
+- Do not break the existing toolbar picker behavior
+- Do not create separate custom-color stores for toolbar and sidebar
+- Do not leave duplicated plain-color controls in Background after the Colors tab is introduced
+- Keep Background-specific layout controls out of the shared Colors panel
+
+## Recommended Implementation Strategy
+1. Add failing regression tests for inspector routing and Background plain-color removal.
+2. Extract or expand shared color-management hooks from the current picker module.
+3. Build the reusable `Colors` inspector panel around those hooks.
+4. Remove `Plain color` from the Background panel.
+5. Route Background and color-capable tools into the shared Colors panel behavior.
+6. Add styling and run final verification.

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1163,13 +1163,35 @@ pub fn install_editor_css() {
                 background-color: transparent;
             }
 
+            .editor-right-inspector {
+                min-width: 280px;
+                background: rgba(20, 20, 20, 0.94);
+                border-left: 1px solid rgba(255,255,255,0.08);
+                padding: 16px;
+            }
+
+            .editor-inspector-title {
+                color: #f5f5f7;
+                font-size: 14px;
+                font-weight: 700;
+            }
+
+            .editor-inspector-placeholder-shell {
+                padding: 2px 0;
+            }
+
+            .editor-inspector-placeholder {
+                opacity: 0.7;
+                color: rgba(241, 241, 243, 0.78);
+                font-size: 12px;
+                line-height: 1.45;
+            }
+
             .editor-background-sidebar {
                 min-width: 210px;
-                padding: 18px 16px;
-                background: linear-gradient(to bottom,
-                    rgba(17, 17, 20, 0.96),
-                    rgba(12, 12, 15, 0.96));
-                border-right: 1px solid rgba(255, 255, 255, 0.08);
+                padding: 0;
+                background: transparent;
+                border-right: none;
             }
 
             .editor-background-sidebar-title {
@@ -2055,6 +2077,7 @@ pub fn recommended_window_size_with_extra_width(
     )
 }
 
+#[allow(dead_code)]
 pub fn recommended_window_size(image_width: i32, image_height: i32) -> (i32, i32) {
     recommended_window_size_with_extra_width(image_width, image_height, 0)
 }

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -296,8 +296,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-crop-type-button > arrow {
-                min-width: 0;
-                min-height: 0;
+                min-width: 20px;
+                min-height: 20px;
                 opacity: 0;
                 color: transparent;
             }
@@ -312,8 +312,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-crop-type-button image {
-                min-width: 0;
-                min-height: 0;
+                min-width: 20px;
+                min-height: 20px;
                 opacity: 0;
             }
 
@@ -512,8 +512,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-color-trigger-menu-button {
-                min-width: 0;
-                min-height: 0;
+                min-width: 20px;
+                min-height: 20px;
                 padding: 0;
                 margin: 0;
                 border: none;
@@ -524,8 +524,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-color-trigger-menu-button > arrow {
-                min-width: 0;
-                min-height: 0;
+                min-width: 20px;
+                min-height: 20px;
                 opacity: 0;
                 color: transparent;
             }
@@ -540,8 +540,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-color-trigger-menu-button image {
-                min-width: 0;
-                min-height: 0;
+                min-width: 20px;
+                min-height: 20px;
                 opacity: 0;
             }
 
@@ -707,12 +707,12 @@ pub fn install_editor_css() {
             }
 
             button.editor-custom-color-remove-button {
-                min-width: 9px;
-                min-height: 9px;
+                min-width: 12px;
+                min-height: 12px;
                 border-radius: 999px;
                 padding: 0;
-                border: 1px solid rgba(255, 255, 255, 0.24);
-                background: #0f0f12;
+                border: 1px solid rgba(232, 17, 35, 0.50);
+                background: #e81123;
                 color: #ffffff;
                 outline: none;
                 box-shadow: 0 1px 3px rgba(0,0,0,0.35);
@@ -723,8 +723,8 @@ pub fn install_editor_css() {
             button.editor-custom-color-remove-button:active,
             button.editor-custom-color-remove-button:focus,
             button.editor-custom-color-remove-button:focus-visible {
-                border: 1px solid rgba(255, 255, 255, 0.34);
-                background: #1a1a20;
+                border: 1px solid rgba(232, 17, 35, 0.70);
+                background: #f02a3b;
                 color: #ffffff;
                 outline: none;
                 box-shadow: 0 2px 5px rgba(0,0,0,0.42);
@@ -734,6 +734,7 @@ pub fn install_editor_css() {
             button.editor-custom-color-remove-button image.editor-custom-color-remove-icon {
                 color: #ffffff;
                 opacity: 0.96;
+                -gtk-icon-size: 10px;
             }
 
             .editor-color-dropdown-footer {
@@ -1163,7 +1164,7 @@ pub fn install_editor_css() {
             }
 
             button.editor-inspector-tab-button {
-                min-height: 0;
+                min-height: 20px;
                 padding: 0;
                 border-radius: 0;
                 border: none;
@@ -1399,7 +1400,7 @@ pub fn install_editor_css() {
             }
 
             .editor-background-compact-slider {
-                min-width: 0;
+                min-width: 32px;
             }
 
             .editor-background-compact-control-spacer {
@@ -1432,8 +1433,8 @@ pub fn install_editor_css() {
             }
 
             .editor-background-alignment-icon-frame {
-                min-width: 12px;
-                min-height: 9px;
+                min-width: 20px;
+                min-height: 20px;
                 background: rgba(241, 241, 243, 0.88);
                 border-radius: 2px;
                 margin: 3px;
@@ -1456,7 +1457,7 @@ pub fn install_editor_css() {
 
             checkbutton.editor-background-checkbox {
                 color: rgba(241, 241, 243, 0.88);
-                min-width: 0;
+                min-width: 20px;
                 padding: 0;
             }
 
@@ -1468,7 +1469,7 @@ pub fn install_editor_css() {
 
             checkbutton.editor-background-checkbox label {
                 color: rgba(241, 241, 243, 0.88);
-                min-width: 0;
+                min-width: 20px;
             }
 
             .editor-background-ratio-dropdown-row {
@@ -1477,13 +1478,13 @@ pub fn install_editor_css() {
 
             dropdown.editor-background-ratio-dropdown {
                 min-height: 32px;
-                min-width: 0;
+                min-width: 20px;
                 padding: 0;
             }
 
             dropdown.editor-background-ratio-dropdown > button {
                 min-height: 32px;
-                min-width: 0;
+                min-width: 20px;
                 border-radius: 8px;
                 padding: 0 6px;
                 background: rgba(255, 255, 255, 0.03);
@@ -2184,7 +2185,7 @@ mod tests {
         let source = include_str!("ui_support.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
-            production_source.contains("button.editor-inspector-tab-button {\n                min-height: 0;\n                padding: 0;\n                border-radius: 0;\n                border: none;\n                background: transparent;")
+            production_source.contains("button.editor-inspector-tab-button {\n                min-height: 20px;\n                padding: 0;\n                border-radius: 0;\n                border: none;\n                background: transparent;")
                 && production_source.contains("button.editor-inspector-tab-button.active-inspector-tab {\n                background: transparent;\n                border: none;\n                color: #ff9900;")
                 && production_source.contains(".editor-colors-panel {\n                min-width: 210px;"),
             "inspector tabs should be text-only with orange active text and colors panel should match background width",

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -457,6 +457,28 @@ pub fn install_editor_css() {
                 margin: 0 2px;
             }
 
+            .editor-toolbar-color-status {
+                min-height: 34px;
+                padding: 0;
+                border: none;
+                background: transparent;
+            }
+
+            .editor-toolbar-color-status-swatch {
+                min-width: 30px;
+                min-height: 30px;
+                border-radius: 6px;
+                border: 1px solid rgba(255, 255, 255, 0.14);
+                background: #121212;
+                box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+            }
+
+            .editor-toolbar-color-status-label {
+                color: rgba(245, 245, 247, 0.92);
+                font-size: 14px;
+                font-weight: 700;
+            }
+
             .editor-color-trigger-shell {
                 min-height: 30px;
                 border-radius: 999px;
@@ -929,11 +951,11 @@ pub fn install_editor_css() {
                 min-width: 220px;
                 min-height: 36px;
                 border-radius: 8px;
-                background: #326ce8;
+                background: #c97800;
                 color: #ffffff;
                 font-weight: 700;
                 font-size: 12px;
-                border: 1px solid rgba(137, 178, 255, 0.55);
+                border: 1px solid rgba(255, 170, 51, 0.5);
                 padding: 0 16px;
                 outline: none;
                 transition: all 150ms ease;
@@ -943,8 +965,8 @@ pub fn install_editor_css() {
             }
 
             button.editor-add-to-colors-button:hover {
-                background: #3a79ff;
-                border-color: rgba(173, 203, 255, 0.66);
+                background: #db8500;
+                border-color: rgba(255, 193, 92, 0.66);
                 box-shadow:
                     0 4px 10px rgba(0, 0, 0, 0.35),
                     inset 0 1px 0 rgba(255, 255, 255, 0.2);
@@ -952,7 +974,7 @@ pub fn install_editor_css() {
             }
 
             button.editor-add-to-colors-button:active {
-                background: #2c5ec9;
+                background: #b36b00;
                 box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.35);
                 transform: translateY(0);
             }
@@ -1136,6 +1158,31 @@ pub fn install_editor_css() {
                 font-weight: 700;
             }
 
+            .editor-inspector-tabs {
+                margin-bottom: 12px;
+            }
+
+            button.editor-inspector-tab-button {
+                min-height: 0;
+                padding: 0;
+                border-radius: 0;
+                border: none;
+                background: transparent;
+                color: rgba(241, 241, 243, 0.82);
+                box-shadow: none;
+            }
+
+            button.editor-inspector-tab-button:hover {
+                background: transparent;
+                color: #ffffff;
+            }
+
+            button.editor-inspector-tab-button.active-inspector-tab {
+                background: transparent;
+                border: none;
+                color: #ff9900;
+            }
+
             .editor-inspector-placeholder-shell {
                 padding: 2px 0;
             }
@@ -1168,6 +1215,54 @@ pub fn install_editor_css() {
 
             .editor-background-sidebar-options {
                 margin-top: 4px;
+            }
+
+            .editor-colors-panel {
+                min-width: 210px;
+                padding: 2px 0;
+            }
+
+            .editor-colors-panel-helper {
+                color: rgba(241, 241, 243, 0.72);
+                font-size: 12px;
+                line-height: 1.45;
+            }
+
+            .editor-colors-panel-section {
+                margin-top: 2px;
+            }
+
+            .editor-colors-panel-current-row {
+                min-height: 32px;
+            }
+
+            .editor-colors-panel-current-preview {
+                min-width: 28px;
+                min-height: 28px;
+                border-radius: 8px;
+                border: 1px solid rgba(255, 255, 255, 0.12);
+                background: rgba(255, 255, 255, 0.08);
+            }
+
+            .editor-colors-panel-current-value {
+                color: rgba(245, 245, 247, 0.92);
+                font-size: 12px;
+                font-weight: 600;
+            }
+
+            .editor-colors-panel-action-button {
+                min-height: 34px;
+                padding: 0 12px;
+                border-radius: 8px;
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                background: rgba(255, 255, 255, 0.03);
+                color: rgba(245, 245, 247, 0.9);
+                box-shadow: none;
+            }
+
+            .editor-colors-panel-action-button:hover {
+                background: rgba(255, 255, 255, 0.07);
+                color: #ffffff;
             }
 
             .editor-background-gradients-section {
@@ -1321,27 +1416,27 @@ pub fn install_editor_css() {
             }
 
             button.editor-background-alignment-button {
-                min-height: 17px;
-                min-width: 26px;
-                border-radius: 6px;
+                min-height: 24px;
+                min-width: 34px;
+                border-radius: 8px;
                 border: 2px solid rgba(255, 255, 255, 0.3);
                 padding: 0;
                 background: rgba(255, 255, 255, 0.03);
             }
 
             .editor-background-alignment-icon {
-                min-width: 26px;
-                min-height: 17px;
+                min-width: 34px;
+                min-height: 24px;
                 border: none;
-                border-radius: 3px;
+                border-radius: 5px;
             }
 
             .editor-background-alignment-icon-frame {
-                min-width: 6px;
-                min-height: 4px;
+                min-width: 12px;
+                min-height: 9px;
                 background: rgba(241, 241, 243, 0.88);
-                border-radius: 1px;
-                margin: 2px;
+                border-radius: 2px;
+                margin: 3px;
                 border: none;
             }
 
@@ -1442,7 +1537,7 @@ pub fn install_editor_css() {
 
             button.editor-background-alignment-button.active-alignment-option {
                 background: rgba(255, 255, 255, 0.15);
-                border: 1px solid #3584e4;
+                border: 1px solid #ff9900;
                 border-radius: 6px;
             }
 
@@ -2058,6 +2153,65 @@ mod tests {
             !production_source.contains(".editor-background-padding-slider > contents")
                 && !production_source.contains(".editor-background-compact-slider > contents"),
             "editor background slider CSS still overrides internal GTK contents nodes"
+        );
+    }
+
+    #[test]
+    fn editor_background_alignment_css_uses_larger_button_and_marker_sizes() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("min-height: 24px;")
+                && production_source.contains("min-width: 34px;")
+                && production_source.contains("min-width: 12px;")
+                && production_source.contains("min-height: 9px;"),
+            "alignment CSS should keep the larger button shell and marker sizes",
+        );
+    }
+
+    #[test]
+    fn editor_background_alignment_active_state_uses_orange_accent() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-background-alignment-button.active-alignment-option {\n                background: rgba(255, 255, 255, 0.15);\n                border: 1px solid #ff9900;"),
+            "alignment selected state should use the orange editor accent",
+        );
+    }
+
+    #[test]
+    fn inspector_tabs_use_text_only_active_state_and_colors_panel_matches_background_width() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-inspector-tab-button {\n                min-height: 0;\n                padding: 0;\n                border-radius: 0;\n                border: none;\n                background: transparent;")
+                && production_source.contains("button.editor-inspector-tab-button.active-inspector-tab {\n                background: transparent;\n                border: none;\n                color: #ff9900;")
+                && production_source.contains(".editor-colors-panel {\n                min-width: 210px;"),
+            "inspector tabs should be text-only with orange active text and colors panel should match background width",
+        );
+    }
+
+    #[test]
+    fn add_to_colors_button_uses_orange_editor_accent() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-add-to-colors-button {\n                min-width: 220px;\n                min-height: 36px;\n                border-radius: 8px;\n                background: #c97800;")
+                && production_source.contains("button.editor-add-to-colors-button:hover {\n                background: #db8500;")
+                && production_source.contains("button.editor-add-to-colors-button:active {\n                background: #b36b00;"),
+            "Add to colors button should use the orange editor accent states",
+        );
+    }
+
+    #[test]
+    fn toolbar_color_status_chip_has_swatch_and_hex_styles() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains(".editor-toolbar-color-status {\n                min-height: 34px;\n                padding: 0;\n                border: none;\n                background: transparent;")
+                && production_source.contains(".editor-toolbar-color-status-swatch {\n                min-width: 30px;\n                min-height: 30px;\n                border-radius: 6px;")
+                && production_source.contains(".editor-toolbar-color-status-label {\n                color: rgba(245, 245, 247, 0.92);\n                font-size: 14px;"),
+            "Toolbar color status chip should have dedicated swatch and label styles",
         );
     }
 

--- a/src/capture/editor/window/background_panel.rs
+++ b/src/capture/editor/window/background_panel.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use super::super::render::rgba_image_to_surface;
 use super::super::state::EditorState;
-use super::super::types::{BackgroundAlignment, BackgroundStyle, CropAspectRatio, DrawColor};
+use super::super::types::{BackgroundAlignment, BackgroundStyle, CropAspectRatio};
 
 pub(super) const BACKGROUND_SIDEBAR_WIDTH: i32 = 210;
 pub(super) const BACKGROUND_GRADIENT_PREVIEW_SIZE: u32 = 96;
@@ -35,8 +35,6 @@ pub(super) struct BackgroundSidebarDensity {
     wide_slider_width: i32,
     compact_slider_width: i32,
     none_button_width: i32,
-    plain_color_row_width: i32,
-    plain_color_button_size: i32,
     preview_size_class: &'static str,
 }
 
@@ -55,8 +53,6 @@ impl BackgroundSidebarDensity {
                 wide_slider_width: width,
                 compact_slider_width: (width - 24) / 2,
                 none_button_width: width,
-                plain_color_row_width: width,
-                plain_color_button_size: 18,
                 preview_size_class: "editor-background-preview-size-compact",
             }
         } else if gradient_count >= 10 {
@@ -72,8 +68,6 @@ impl BackgroundSidebarDensity {
                 wide_slider_width: width,
                 compact_slider_width: (width - 24) / 2,
                 none_button_width: width,
-                plain_color_row_width: width,
-                plain_color_button_size: 21,
                 preview_size_class: "editor-background-preview-size-medium",
             }
         } else {
@@ -89,8 +83,6 @@ impl BackgroundSidebarDensity {
                 wide_slider_width: width,
                 compact_slider_width: (width - 24) / 2,
                 none_button_width: width,
-                plain_color_row_width: width,
-                plain_color_button_size: 24,
                 preview_size_class: "editor-background-preview-size-regular",
             }
         }
@@ -141,48 +133,6 @@ const BACKGROUND_GRADIENT_PREVIEW_CLASSES: [&str; 20] = [
     "editor-background-gradient-preview-19",
     "editor-background-gradient-preview-20",
 ];
-const BACKGROUND_PLAIN_COLOR_CLASSES: [&str; 18] = [
-    "editor-background-plain-color-1",
-    "editor-background-plain-color-2",
-    "editor-background-plain-color-3",
-    "editor-background-plain-color-4",
-    "editor-background-plain-color-5",
-    "editor-background-plain-color-6",
-    "editor-background-plain-color-7",
-    "editor-background-plain-color-8",
-    "editor-background-plain-color-9",
-    "editor-background-plain-color-10",
-    "editor-background-plain-color-11",
-    "editor-background-plain-color-12",
-    "editor-background-plain-color-13",
-    "editor-background-plain-color-14",
-    "editor-background-plain-color-15",
-    "editor-background-plain-color-16",
-    "editor-background-plain-color-17",
-    "editor-background-plain-color-18",
-];
-
-const BACKGROUND_PLAIN_COLOR_VALUES: [DrawColor; 18] = [
-    DrawColor::new(1.0, 1.0, 1.0, 1.0),
-    DrawColor::new(0.898, 0.906, 0.922, 1.0),
-    DrawColor::new(0.612, 0.639, 0.686, 1.0),
-    DrawColor::new(0.067, 0.094, 0.153, 1.0),
-    DrawColor::new(0.937, 0.267, 0.267, 1.0),
-    DrawColor::new(0.976, 0.451, 0.086, 1.0),
-    DrawColor::new(0.98, 0.8, 0.082, 1.0),
-    DrawColor::new(0.133, 0.773, 0.369, 1.0),
-    DrawColor::new(0.078, 0.722, 0.651, 1.0),
-    DrawColor::new(0.024, 0.714, 0.831, 1.0),
-    DrawColor::new(0.231, 0.51, 0.965, 1.0),
-    DrawColor::new(0.388, 0.4, 0.945, 1.0),
-    DrawColor::new(0.545, 0.361, 0.965, 1.0),
-    DrawColor::new(0.659, 0.333, 0.969, 1.0),
-    DrawColor::new(0.925, 0.282, 0.6, 1.0),
-    DrawColor::new(0.957, 0.247, 0.369, 1.0),
-    DrawColor::new(0.573, 0.251, 0.055, 1.0),
-    DrawColor::new(0.059, 0.463, 0.431, 1.0),
-];
-
 pub fn background_gradient_asset_path(file_name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("src/capture/editor/background-images")
@@ -493,24 +443,6 @@ fn build_background_blurred_preview_button(
     button
 }
 
-fn build_background_plain_color_button(index: usize, density: BackgroundSidebarDensity) -> Button {
-    let button = Button::new();
-    button.set_has_frame(false);
-    button.set_focusable(false);
-    button.set_hexpand(false);
-    button.set_vexpand(false);
-    button.set_halign(gtk4::Align::Center);
-    button.set_valign(gtk4::Align::Center);
-    button.set_size_request(
-        density.plain_color_button_size,
-        density.plain_color_button_size,
-    );
-    button.add_css_class("editor-background-plain-color-button");
-    button.add_css_class(BACKGROUND_PLAIN_COLOR_CLASSES[index]);
-    button.set_tooltip_text(Some(&format!("Plain color {}", index + 1)));
-    button
-}
-
 fn clear_active_alignment_classes(widget: &gtk4::Widget) {
     if let Some(btn) = widget.downcast_ref::<Button>() {
         btn.remove_css_class("active-alignment-option");
@@ -521,19 +453,6 @@ fn clear_active_alignment_classes(widget: &gtk4::Widget) {
         clear_active_alignment_classes(&c);
         child = c.next_sibling();
     }
-}
-
-pub(super) fn build_background_plain_color_cell(
-    index: usize,
-    density: BackgroundSidebarDensity,
-) -> GtkBox {
-    let cell = GtkBox::new(Orientation::Vertical, 0);
-    cell.add_css_class("editor-background-plain-color-cell");
-    cell.set_hexpand(false);
-    cell.set_halign(gtk4::Align::Fill);
-    cell.set_valign(gtk4::Align::Center);
-    cell.append(&build_background_plain_color_button(index, density));
-    cell
 }
 
 fn clear_active_background_classes(widget: &gtk4::Widget) {
@@ -1030,65 +949,6 @@ pub(super) fn build_background_panel(
     blurred_section.append(&blurred_title);
     blurred_section.append(&blurred_row);
 
-    let plain_color_section = GtkBox::new(Orientation::Vertical, density.section_spacing);
-    plain_color_section.add_css_class("editor-background-plain-color-section");
-
-    let plain_color_title = Label::new(Some("Plain color"));
-    plain_color_title.add_css_class("editor-background-section-title");
-    plain_color_title.set_xalign(0.0);
-
-    let plain_color_grid = GtkBox::new(Orientation::Vertical, density.preview_row_spacing);
-    plain_color_grid.add_css_class("editor-background-plain-color-grid");
-
-    for row_index in 0..2 {
-        let plain_color_row = GtkBox::new(Orientation::Horizontal, density.preview_row_spacing);
-        plain_color_row.add_css_class("editor-background-plain-color-row");
-        plain_color_row.set_hexpand(false);
-        plain_color_row.set_halign(gtk4::Align::Fill);
-        plain_color_row.set_homogeneous(true);
-        plain_color_row.set_size_request(density.plain_color_row_width, -1);
-
-        for column_index in 0..9 {
-            let color_index = row_index * 9 + column_index;
-            let color_cell = build_background_plain_color_cell(color_index, density);
-            if let Some(btn) = color_cell
-                .first_child()
-                .and_then(|c| c.downcast::<Button>().ok())
-            {
-                {
-                    let st = state.lock().unwrap();
-                    if let BackgroundStyle::PlainColor(color) = st.background_style {
-                        if color == BACKGROUND_PLAIN_COLOR_VALUES[color_index] {
-                            btn.add_css_class("active-background-option");
-                        }
-                    }
-                }
-
-                btn.connect_clicked({
-                    let state = state.clone();
-                    let sidebar = background_sidebar.clone();
-                    let btn = btn.clone();
-                    let color = BACKGROUND_PLAIN_COLOR_VALUES[color_index];
-                    let drawing_area = drawing_area.clone();
-                    move |_| {
-                        let mut st = state.lock().unwrap();
-                        st.background_style = BackgroundStyle::PlainColor(color);
-                        clear_active_background_classes(sidebar.upcast_ref());
-                        btn.add_css_class("active-background-option");
-                        st.mark_working_image_dirty();
-                        drawing_area.queue_draw();
-                    }
-                });
-            }
-            plain_color_row.append(&color_cell);
-        }
-
-        plain_color_grid.append(&plain_color_row);
-    }
-
-    plain_color_section.append(&plain_color_title);
-    plain_color_section.append(&plain_color_grid);
-
     let background_padding_divider_row = GtkBox::new(Orientation::Horizontal, 0);
     background_padding_divider_row.add_css_class("editor-background-divider-row");
     let background_padding_divider = GtkBox::new(Orientation::Horizontal, 0);
@@ -1291,6 +1151,9 @@ pub(super) fn build_background_panel(
 
     let alignment_section = GtkBox::new(Orientation::Vertical, 4);
     alignment_section.add_css_class("editor-background-compact-slider-section");
+    alignment_section.set_size_request(density.none_button_width, -1);
+    alignment_section.set_halign(gtk4::Align::Fill);
+    alignment_section.set_hexpand(false);
 
     let alignment_title = Label::new(Some("Alignment"));
     alignment_title.add_css_class("editor-background-section-title");
@@ -1298,7 +1161,9 @@ pub(super) fn build_background_panel(
 
     let alignment_grid = GtkBox::new(Orientation::Vertical, 4);
     alignment_grid.add_css_class("editor-background-alignment-grid");
-    alignment_grid.set_halign(gtk4::Align::Start);
+    alignment_grid.set_size_request(density.none_button_width, -1);
+    alignment_grid.set_halign(gtk4::Align::Fill);
+    alignment_grid.set_hexpand(false);
 
     let alignment_positions = [
         [
@@ -1322,12 +1187,15 @@ pub(super) fn build_background_panel(
         let alignment_row = GtkBox::new(Orientation::Horizontal, 4);
         alignment_row.add_css_class("editor-background-alignment-row");
         alignment_row.set_homogeneous(true);
+        alignment_row.set_size_request(density.none_button_width, -1);
+        alignment_row.set_halign(gtk4::Align::Fill);
+        alignment_row.set_hexpand(false);
 
         for (position_class, tooltip) in row_items {
             let alignment_frame = GtkBox::new(Orientation::Horizontal, 0);
             alignment_frame.add_css_class("editor-background-alignment-icon-frame");
             alignment_frame.add_css_class(position_class);
-            alignment_frame.set_size_request(6, 4);
+            alignment_frame.set_size_request(12, 9);
 
             match position_class {
                 "top-left" => {
@@ -1371,7 +1239,7 @@ pub(super) fn build_background_panel(
 
             let alignment_icon = gtk4::Overlay::new();
             alignment_icon.add_css_class("editor-background-alignment-icon");
-            alignment_icon.set_size_request(26, 17);
+            alignment_icon.set_size_request(34, 24);
             alignment_icon.set_child(Some(&alignment_frame));
 
             let alignment_button = Button::new();
@@ -1424,7 +1292,6 @@ pub(super) fn build_background_panel(
 
     alignment_section.append(&alignment_title);
     alignment_section.append(&alignment_grid);
-    shadow_section.append(&alignment_section);
 
     let corners_section = GtkBox::new(Orientation::Vertical, 4);
     corners_section.add_css_class("editor-background-compact-slider-section");
@@ -1433,6 +1300,9 @@ pub(super) fn build_background_panel(
 
     let ratio_section = GtkBox::new(Orientation::Vertical, 4);
     ratio_section.add_css_class("editor-background-compact-slider-section");
+    ratio_section.set_size_request(density.wide_slider_width, -1);
+    ratio_section.set_halign(gtk4::Align::Fill);
+    ratio_section.set_hexpand(false);
 
     let ratio_title = Label::new(Some("Ratio"));
     ratio_title.add_css_class("editor-background-section-title");
@@ -1440,9 +1310,12 @@ pub(super) fn build_background_panel(
 
     let ratio_dropdown_row = GtkBox::new(Orientation::Horizontal, 0);
     ratio_dropdown_row.add_css_class("editor-background-ratio-dropdown-row");
+    ratio_dropdown_row.set_size_request(density.wide_slider_width, -1);
+    ratio_dropdown_row.set_halign(gtk4::Align::Fill);
+    ratio_dropdown_row.set_hexpand(false);
     let ratio_dropdown = gtk4::DropDown::from_strings(&["Original", "1:1", "4:3", "16:9", "21:9"]);
     ratio_dropdown.add_css_class("editor-background-ratio-dropdown");
-    ratio_dropdown.set_size_request(density.compact_slider_width, -1);
+    ratio_dropdown.set_size_request(density.wide_slider_width, -1);
     ratio_dropdown.set_halign(gtk4::Align::Fill);
     ratio_dropdown.set_hexpand(true);
     ratio_dropdown.set_selected(0);
@@ -1501,7 +1374,6 @@ pub(super) fn build_background_panel(
 
     corners_section.append(&corners_title);
     corners_section.append(&corners_slider_row);
-    corners_section.append(&ratio_section);
 
     shadow_corners_row.append(&shadow_section);
     shadow_corners_row.append(&corners_section);
@@ -1510,12 +1382,13 @@ pub(super) fn build_background_panel(
     compact_controls.append(&shadow_corners_row);
 
     background_sidebar_options.append(&background_none_btn);
+    background_sidebar_options.append(&alignment_section);
     background_sidebar_options.append(&gradients_section);
     background_sidebar_options.append(&wallpaper_section);
     background_sidebar_options.append(&blurred_section);
-    background_sidebar_options.append(&plain_color_section);
     background_sidebar_options.append(&background_padding_divider_row);
     background_sidebar_options.append(&padding_section);
+    background_sidebar_options.append(&ratio_section);
     background_sidebar_options.append(&compact_controls);
 
     background_sidebar.append(&background_sidebar_options);
@@ -1523,5 +1396,84 @@ pub(super) fn build_background_panel(
     BackgroundPanelParts {
         root: background_sidebar,
         start_gradient_preview_loading: start_background_gradient_preview_loading,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn alignment_section_is_placed_below_none_button_and_before_gradients() {
+        let source = include_str!("background_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        let none_append = production_source
+            .find("background_sidebar_options.append(&background_none_btn);")
+            .expect("expected None button to be appended to background sidebar options");
+        let alignment_append = production_source
+            .find("background_sidebar_options.append(&alignment_section);")
+            .expect("expected alignment section to be appended to background sidebar options");
+        let gradients_append = production_source
+            .find("background_sidebar_options.append(&gradients_section);")
+            .expect("expected gradients section to be appended to background sidebar options");
+
+        assert!(
+            none_append < alignment_append && alignment_append < gradients_append,
+            "alignment section should render between the None button and gradients section",
+        );
+        assert!(
+            !production_source.contains("shadow_section.append(&alignment_section);"),
+            "alignment section should no longer be nested under the shadow section",
+        );
+    }
+
+    #[test]
+    fn alignment_preview_widgets_use_larger_full_width_sizes() {
+        let source = include_str!("background_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        assert!(
+            production_source.contains("alignment_frame.set_size_request(12, 9);"),
+            "alignment marker should use the enlarged preview marker size",
+        );
+        assert!(
+            production_source.contains("alignment_icon.set_size_request(34, 24);"),
+            "alignment icon should use the enlarged full-width button preview size",
+        );
+    }
+
+    #[test]
+    fn ratio_section_is_placed_below_padding_and_not_nested_under_corners() {
+        let source = include_str!("background_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        let padding_append = production_source
+            .find("background_sidebar_options.append(&padding_section);")
+            .expect("expected padding section to be appended to background sidebar options");
+        let ratio_append = production_source
+            .find("background_sidebar_options.append(&ratio_section);")
+            .expect("expected ratio section to be appended to background sidebar options");
+        let compact_append = production_source
+            .find("background_sidebar_options.append(&compact_controls);")
+            .expect("expected compact controls to be appended to background sidebar options");
+
+        assert!(
+            padding_append < ratio_append && ratio_append < compact_append,
+            "ratio section should render between padding and compact controls",
+        );
+        assert!(
+            !production_source.contains("corners_section.append(&ratio_section);"),
+            "ratio section should no longer be nested under the corners section",
+        );
+    }
+
+    #[test]
+    fn background_panel_no_longer_appends_plain_color_section() {
+        let source = include_str!("background_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            !production_source.contains("plain_color_section.append(&plain_color_title);")
+                && !production_source.contains("background_sidebar_options.append(&plain_color_section);"),
+            "Background panel should no longer render the embedded plain-color section",
+        );
     }
 }

--- a/src/capture/editor/window/background_panel.rs
+++ b/src/capture/editor/window/background_panel.rs
@@ -648,7 +648,7 @@ fn rebuild_wallpaper_preview_grid(
 }
 
 pub(super) struct BackgroundPanelParts {
-    pub sidebar: GtkBox,
+    pub root: GtkBox,
     pub start_gradient_preview_loading: Rc<dyn Fn()>,
 }
 
@@ -1521,7 +1521,7 @@ pub(super) fn build_background_panel(
     background_sidebar.append(&background_sidebar_options);
 
     BackgroundPanelParts {
-        sidebar: background_sidebar,
+        root: background_sidebar,
         start_gradient_preview_loading: start_background_gradient_preview_loading,
     }
 }

--- a/src/capture/editor/window/canvas.rs
+++ b/src/capture/editor/window/canvas.rs
@@ -1,4 +1,5 @@
 use gtk4::{prelude::*, Box as GtkBox, DrawingArea, Orientation, Overlay, ScrolledWindow};
+use gtk4::cairo::Antialias;
 use image::RgbaImage;
 use std::f64::consts::TAU;
 
@@ -200,6 +201,9 @@ pub(super) fn draw_eyedropper_loupe(
     context.arc(center_x, center_y, radius, 0.0, TAU);
     let _ = context.clip();
 
+    // Disable antialiasing for crisp pixel edges
+    context.set_antialias(Antialias::None);
+
     context.set_source_rgba(0.06, 0.07, 0.09, 0.94);
     let _ = context.paint();
 
@@ -222,41 +226,32 @@ pub(super) fn draw_eyedropper_loupe(
             let dest_x = grid_start_x + col as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
             let dest_y = grid_start_y + row as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
             context.rectangle(
-                dest_x.floor(),
-                dest_y.floor(),
-                EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5,
-                EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5,
+                dest_x,
+                dest_y,
+                EYEDROPPER_LOUPE_PIXEL_SIZE,
+                EYEDROPPER_LOUPE_PIXEL_SIZE,
             );
             let _ = context.fill();
         }
     }
 
-    context.set_source_rgba(0.0, 0.0, 0.0, 0.24);
+    context.set_source_rgba(0.0, 0.0, 0.0, 0.28);
     context.set_line_width(1.0);
     for line in 0..=grid_size {
-        let x = grid_start_x + line as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5;
+        let x = grid_start_x + line as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
         context.move_to(x, grid_start_y);
         context.line_to(x, grid_start_y + grid_extent);
 
-        let y = grid_start_y + line as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5;
+        let y = grid_start_y + line as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
         context.move_to(grid_start_x, y);
         context.line_to(grid_start_x + grid_extent, y);
     }
     let _ = context.stroke();
 
-    let _ = context.restore();
-
-    context.arc(center_x, center_y, radius - 0.5, 0.0, TAU);
-    context.set_source_rgba(1.0, 1.0, 1.0, 0.98);
-    context.set_line_width(2.6);
-    let _ = context.stroke_preserve();
-    context.set_source_rgba(0.0, 0.0, 0.0, 0.74);
-    context.set_line_width(1.2);
-    let _ = context.stroke();
-
-    let target_x = grid_start_x + half_grid as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5;
-    let target_y = grid_start_y + half_grid as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE + 0.5;
-    let target_size = EYEDROPPER_LOUPE_PIXEL_SIZE - 1.0;
+    // Draw target pixel highlight (center pixel)
+    let target_x = grid_start_x + half_grid as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
+    let target_y = grid_start_y + half_grid as f64 * EYEDROPPER_LOUPE_PIXEL_SIZE;
+    let target_size = EYEDROPPER_LOUPE_PIXEL_SIZE;
 
     context.rectangle(target_x, target_y, target_size, target_size);
     context.set_source_rgba(0.0, 0.0, 0.0, 0.96);
@@ -264,5 +259,16 @@ pub(super) fn draw_eyedropper_loupe(
     let _ = context.stroke_preserve();
     context.set_source_rgba(1.0, 1.0, 1.0, 0.97);
     context.set_line_width(1.0);
+    let _ = context.stroke();
+
+    let _ = context.restore();
+
+    // Draw outer ring with antialiasing for smoothness
+    context.arc(center_x, center_y, radius - 0.5, 0.0, TAU);
+    context.set_source_rgba(1.0, 1.0, 1.0, 0.98);
+    context.set_line_width(2.6);
+    let _ = context.stroke_preserve();
+    context.set_source_rgba(0.0, 0.0, 0.0, 0.74);
+    context.set_line_width(1.2);
     let _ = context.stroke();
 }

--- a/src/capture/editor/window/color_picker.rs
+++ b/src/capture/editor/window/color_picker.rs
@@ -42,6 +42,9 @@ pub struct ColorPickerParts {
     pub sync_picker_from_color: Rc<dyn Fn(DrawColor)>,
     pub apply_picker_color: Rc<dyn Fn(DrawColor)>,
     pub set_picker_panel_visibility: Rc<dyn Fn(bool)>,
+    pub custom_slot_colors: Rc<RefCell<Vec<Option<DrawColor>>>>,
+    pub refresh_custom_color_slots: Rc<dyn Fn()>,
+    pub register_external_sync: Rc<dyn Fn(Rc<dyn Fn()>)>,
 }
 
 pub fn build_color_picker(
@@ -296,6 +299,7 @@ pub fn build_color_picker(
         DRAW_COLORS[DEFAULT_COLOR_INDEX],
     )));
     let picker_update_in_progress = Rc::new(Cell::new(false));
+    let external_sync = Rc::new(RefCell::new(None::<Rc<dyn Fn()>>));
 
     // Gradient area
     let gradient_area = DrawingArea::new();
@@ -642,6 +646,7 @@ pub fn build_color_picker(
         let color_picker_dot_picker = color_picker_dot.clone();
         let color_class_names_picker = color_class_names.clone();
         let drawing_area_picker = drawing_area.clone();
+        let external_sync = external_sync.clone();
         move |color| {
             let has_active_text = {
                 let mut st = state_picker_apply.lock().unwrap();
@@ -678,6 +683,9 @@ pub fn build_color_picker(
                 }
             }
             canvas_queue_draw_signal();
+            if let Some(sync) = external_sync.borrow().as_ref() {
+                sync();
+            }
         }
     });
 
@@ -934,6 +942,7 @@ pub fn build_color_picker(
     let add_color_to_custom_slots: Rc<dyn Fn(super::super::types::DrawColor)> = Rc::new({
         let custom_slot_colors = custom_slot_colors.clone();
         let refresh_custom_color_slots = refresh_custom_color_slots.clone();
+        let external_sync = external_sync.clone();
         move |color_to_add| {
             let mut custom_colors = custom_slot_colors.borrow_mut();
             let Some(slot_index) = custom_colors.iter().position(Option::is_none) else {
@@ -944,6 +953,9 @@ pub fn build_color_picker(
             save_persisted_custom_slot_colors(custom_colors.as_slice());
             drop(custom_colors);
             refresh_custom_color_slots();
+            if let Some(sync) = external_sync.borrow().as_ref() {
+                sync();
+            }
         }
     });
 
@@ -994,6 +1006,7 @@ pub fn build_color_picker(
         let custom_slot_colors_drop = custom_slot_colors.clone();
         let refresh_custom_color_slots_drop = refresh_custom_color_slots.clone();
         let suppress_custom_slot_click_once_drop = suppress_custom_slot_click_once.clone();
+        let external_sync_drop = external_sync.clone();
         drop_target.connect_drop(move |_, value, _, _| {
             let Ok(from_index_raw) = value.get::<u32>() else {
                 return false;
@@ -1012,6 +1025,9 @@ pub fn build_color_picker(
                 refresh_custom_color_slots_drop();
                 save_persisted_custom_slot_colors(custom_slot_colors_drop.borrow().as_slice());
                 suppress_custom_slot_click_once_drop.set(true);
+                if let Some(sync) = external_sync_drop.borrow().as_ref() {
+                    sync();
+                }
             }
 
             moved
@@ -1046,6 +1062,7 @@ pub fn build_color_picker(
     for (index, remove_button) in custom_slot_remove_buttons.iter().enumerate() {
         let custom_slot_colors_remove = custom_slot_colors.clone();
         let refresh_custom_color_slots_remove = refresh_custom_color_slots.clone();
+        let external_sync_remove = external_sync.clone();
         remove_button.connect_clicked(move |_| {
             let mut custom_colors = custom_slot_colors_remove.borrow_mut();
             if custom_colors[index].is_none() {
@@ -1056,8 +1073,18 @@ pub fn build_color_picker(
             save_persisted_custom_slot_colors(custom_colors.as_slice());
             drop(custom_colors);
             refresh_custom_color_slots_remove();
+            if let Some(sync) = external_sync_remove.borrow().as_ref() {
+                sync();
+            }
         });
     }
+
+    let register_external_sync: Rc<dyn Fn(Rc<dyn Fn()>)> = Rc::new({
+        let external_sync = external_sync.clone();
+        move |sync| {
+            *external_sync.borrow_mut() = Some(sync);
+        }
+    });
 
     ColorPickerParts {
         trigger_host: color_picker_trigger_host,
@@ -1070,6 +1097,9 @@ pub fn build_color_picker(
         sync_picker_from_color,
         apply_picker_color: apply_picker_color_to_editor,
         set_picker_panel_visibility,
+        custom_slot_colors,
+        refresh_custom_color_slots,
+        register_external_sync,
     }
 }
 
@@ -1107,6 +1137,27 @@ pub fn set_color_picker_trigger_dot_state(
     }
 }
 
+pub fn activate_eyedropper(
+    color_popover: &Popover,
+    state: Arc<Mutex<EditorState>>,
+    eyedropper_mode: Rc<Cell<bool>>,
+    eyedropper_point: Rc<RefCell<Option<Point>>>,
+    eyedropper_rendered: Rc<RefCell<Option<RgbaImage>>>,
+    canvas_eyedropper_ring: &DrawingArea,
+    drawing_area: &DrawingArea,
+    set_cursor_crosshair: Rc<dyn Fn()>,
+) {
+    color_popover.popdown();
+    eyedropper_mode.set(true);
+    *eyedropper_point.borrow_mut() = None;
+    *eyedropper_rendered.borrow_mut() = state.lock().unwrap().to_rendered_image().ok();
+    canvas_eyedropper_ring.set_visible(false);
+    canvas_eyedropper_ring.queue_draw();
+    set_cursor_crosshair();
+
+    drawing_area.queue_draw();
+}
+
 pub fn connect_eyedropper_activation(
     eyedropper_btn: &Button,
     color_popover: &Popover,
@@ -1120,18 +1171,17 @@ pub fn connect_eyedropper_activation(
 ) {
     let color_popover = color_popover.clone();
     let canvas_eyedropper_ring = canvas_eyedropper_ring.clone();
-    let drawing_area = drawing_area.downgrade();
+    let drawing_area = drawing_area.clone();
     eyedropper_btn.connect_clicked(move |_| {
-        color_popover.popdown();
-        eyedropper_mode.set(true);
-        *eyedropper_point.borrow_mut() = None;
-        *eyedropper_rendered.borrow_mut() = state.lock().unwrap().to_rendered_image().ok();
-        canvas_eyedropper_ring.set_visible(false);
-        canvas_eyedropper_ring.queue_draw();
-        set_cursor_crosshair();
-
-        if let Some(area) = drawing_area.upgrade() {
-            area.queue_draw();
-        }
+        activate_eyedropper(
+            &color_popover,
+            state.clone(),
+            eyedropper_mode.clone(),
+            eyedropper_point.clone(),
+            eyedropper_rendered.clone(),
+            &canvas_eyedropper_ring,
+            &drawing_area,
+            set_cursor_crosshair.clone(),
+        );
     });
 }

--- a/src/capture/editor/window/colors_panel.rs
+++ b/src/capture/editor/window/colors_panel.rs
@@ -1,0 +1,831 @@
+use gtk4::gdk;
+use gtk4::prelude::*;
+use gtk4::{
+    Box as GtkBox, Button, CssProvider, DrawingArea, EventControllerMotion, GestureClick, Label,
+    Orientation, Overlay, Scale,
+};
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use super::background_panel::BACKGROUND_SIDEBAR_WIDTH;
+use super::super::color::{
+    draw_color_to_hex, draw_color_to_rgba_u8, palette_index_for_color, parse_alpha_percent,
+    parse_channel_u8, parse_hex_rgb, picker_dynamic_css, save_persisted_custom_slot_colors,
+    DRAW_COLORS,
+};
+use super::super::state::EditorState;
+use super::super::types::{BackgroundStyle, DrawColor, PickerColorState, Tool};
+use super::super::ui_support::{color_swatch_button, set_active_color_button};
+use super::icon_names;
+
+const SIDEBAR_PALETTE_SPECS: [(&str, &str); 12] = [
+    ("Black", "editor-color-black"),
+    ("Blue", "editor-color-blue"),
+    ("Dark Green", "editor-color-dark-green"),
+    ("Red", "editor-color-red"),
+    ("Orange", "editor-color-orange"),
+    ("Yellow", "editor-color-yellow"),
+    ("Green", "editor-color-green"),
+    ("Cyan", "editor-color-cyan"),
+    ("Blue Bright", "editor-color-blue-bright"),
+    ("Purple", "editor-color-purple"),
+    ("Pink", "editor-color-pink"),
+    ("White", "editor-color-white"),
+];
+
+pub struct ColorsPanelParts {
+    pub root: GtkBox,
+    pub sync_for_active_tool: Rc<dyn Fn()>,
+}
+
+pub fn build_colors_panel(
+    state: Arc<Mutex<EditorState>>,
+    apply_picker_color: Rc<dyn Fn(DrawColor)>,
+    custom_slot_colors: Rc<RefCell<Vec<Option<DrawColor>>>>,
+    refresh_shared_custom_color_slots: Rc<dyn Fn()>,
+    activate_eyedropper: Rc<dyn Fn()>,
+) -> ColorsPanelParts {
+    let root = GtkBox::new(Orientation::Vertical, 12);
+    root.add_css_class("editor-colors-panel");
+    root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
+    root.set_hexpand(true);
+    root.set_halign(gtk4::Align::Fill);
+    root.set_vexpand(true);
+
+    let content = GtkBox::new(Orientation::Vertical, 12);
+    content.set_hexpand(true);
+    content.set_halign(gtk4::Align::Fill);
+
+    let helper = Label::new(Some("Choose a color for the active tool"));
+    helper.add_css_class("editor-colors-panel-helper");
+    helper.set_wrap(true);
+    helper.set_max_width_chars(26);
+    helper.set_xalign(0.0);
+
+    let picker_state = Rc::new(RefCell::new(PickerColorState::from_color(DRAW_COLORS[0])));
+    let picker_update_in_progress = Rc::new(Cell::new(false));
+    let picker_css_provider = CssProvider::new();
+    if let Some(display) = gdk::Display::default() {
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &picker_css_provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER,
+        );
+    }
+
+    let spectrum_section = GtkBox::new(Orientation::Vertical, 8);
+    spectrum_section.add_css_class("editor-colors-panel-section");
+    spectrum_section.set_hexpand(true);
+    spectrum_section.set_halign(gtk4::Align::Fill);
+
+    let gradient_area = DrawingArea::new();
+    gradient_area.set_content_width(BACKGROUND_SIDEBAR_WIDTH);
+    gradient_area.set_content_height(140);
+    gradient_area.set_size_request(BACKGROUND_SIDEBAR_WIDTH, 140);
+    gradient_area.set_halign(gtk4::Align::Fill);
+    gradient_area.set_hexpand(true);
+    gradient_area.add_css_class("editor-gradient-area");
+    let picker_state_draw = picker_state.clone();
+    gradient_area.set_draw_func(move |_area, cr: &gtk4::cairo::Context, width, height| {
+        let picker = *picker_state_draw.borrow();
+        let w = width as f64;
+        let h = height as f64;
+        let (hue_r, hue_g, hue_b) = super::super::types::hsv_to_rgb(picker.hue, 1.0, 1.0);
+        cr.set_source_rgb(hue_r, hue_g, hue_b);
+        cr.rectangle(0.0, 0.0, w, h);
+        let _ = cr.fill();
+        let white_grad = gtk4::cairo::LinearGradient::new(0.0, 0.0, w, 0.0);
+        white_grad.add_color_stop_rgba(0.0, 1.0, 1.0, 1.0, 1.0);
+        white_grad.add_color_stop_rgba(1.0, 1.0, 1.0, 1.0, 0.0);
+        let _ = cr.set_source(&white_grad);
+        cr.rectangle(0.0, 0.0, w, h);
+        let _ = cr.fill();
+        let black_grad = gtk4::cairo::LinearGradient::new(0.0, 0.0, 0.0, h);
+        black_grad.add_color_stop_rgba(0.0, 0.0, 0.0, 0.0, 0.0);
+        black_grad.add_color_stop_rgba(1.0, 0.0, 0.0, 0.0, 1.0);
+        let _ = cr.set_source(&black_grad);
+        cr.rectangle(0.0, 0.0, w, h);
+        let _ = cr.fill();
+        let cx = picker.saturation * w;
+        let cy = (1.0 - picker.value) * h;
+        cr.set_source_rgba(1.0, 1.0, 1.0, 0.9);
+        cr.set_line_width(2.0);
+        cr.arc(cx, cy, 6.0, 0.0, std::f64::consts::TAU);
+        let _ = cr.stroke();
+    });
+
+    let hue_slider = Scale::with_range(Orientation::Horizontal, 0.0, 360.0, 1.0);
+    hue_slider.set_draw_value(false);
+    hue_slider.set_hexpand(true);
+    hue_slider.set_halign(gtk4::Align::Fill);
+    hue_slider.add_css_class("editor-hue-slider");
+
+    let opacity_slider = Scale::with_range(Orientation::Horizontal, 0.0, 100.0, 1.0);
+    opacity_slider.set_draw_value(false);
+    opacity_slider.set_hexpand(true);
+    opacity_slider.set_halign(gtk4::Align::Fill);
+    opacity_slider.add_css_class("editor-opacity-slider");
+    opacity_slider.set_widget_name("editor-sidebar-picker-opacity-slider");
+
+    let hex_entry = gtk4::Entry::new();
+    hex_entry.set_max_length(6);
+    hex_entry.set_width_chars(6);
+    hex_entry.set_max_width_chars(6);
+    hex_entry.set_halign(gtk4::Align::Fill);
+    hex_entry.set_hexpand(true);
+    gtk4::prelude::EditableExt::set_alignment(&hex_entry, 0.5);
+    hex_entry.add_css_class("editor-hex-entry");
+
+    let hex_label = Label::new(Some("HEX"));
+    hex_label.add_css_class("editor-color-field-label");
+    hex_label.set_halign(gtk4::Align::Center);
+    hex_label.set_xalign(0.5);
+
+    let hex_row = GtkBox::new(Orientation::Vertical, 2);
+    hex_row.set_halign(gtk4::Align::Fill);
+    hex_row.set_hexpand(true);
+    hex_row.append(&hex_entry);
+    hex_row.append(&hex_label);
+
+    let rgba_row = GtkBox::new(Orientation::Horizontal, 6);
+    rgba_row.set_halign(gtk4::Align::Fill);
+    rgba_row.set_hexpand(true);
+    rgba_row.set_homogeneous(true);
+
+    let r_entry = gtk4::Entry::new();
+    r_entry.set_max_length(3);
+    r_entry.set_width_chars(3);
+    r_entry.set_max_width_chars(3);
+    r_entry.set_halign(gtk4::Align::Fill);
+    r_entry.set_hexpand(true);
+    gtk4::prelude::EditableExt::set_alignment(&r_entry, 0.5);
+    r_entry.add_css_class("editor-rgba-entry");
+    let r_label = Label::new(Some("R"));
+    r_label.add_css_class("editor-color-field-label");
+    r_label.set_halign(gtk4::Align::Center);
+    r_label.set_xalign(0.5);
+    let r_col = GtkBox::new(Orientation::Vertical, 2);
+    r_col.set_halign(gtk4::Align::Fill);
+    r_col.set_hexpand(true);
+    r_col.append(&r_entry);
+    r_col.append(&r_label);
+    rgba_row.append(&r_col);
+
+    let g_entry = gtk4::Entry::new();
+    g_entry.set_max_length(3);
+    g_entry.set_width_chars(3);
+    g_entry.set_max_width_chars(3);
+    g_entry.set_halign(gtk4::Align::Fill);
+    g_entry.set_hexpand(true);
+    gtk4::prelude::EditableExt::set_alignment(&g_entry, 0.5);
+    g_entry.add_css_class("editor-rgba-entry");
+    let g_label = Label::new(Some("G"));
+    g_label.add_css_class("editor-color-field-label");
+    g_label.set_halign(gtk4::Align::Center);
+    g_label.set_xalign(0.5);
+    let g_col = GtkBox::new(Orientation::Vertical, 2);
+    g_col.set_halign(gtk4::Align::Fill);
+    g_col.set_hexpand(true);
+    g_col.append(&g_entry);
+    g_col.append(&g_label);
+    rgba_row.append(&g_col);
+
+    let b_entry = gtk4::Entry::new();
+    b_entry.set_max_length(3);
+    b_entry.set_width_chars(3);
+    b_entry.set_max_width_chars(3);
+    b_entry.set_halign(gtk4::Align::Fill);
+    b_entry.set_hexpand(true);
+    gtk4::prelude::EditableExt::set_alignment(&b_entry, 0.5);
+    b_entry.add_css_class("editor-rgba-entry");
+    let b_label = Label::new(Some("B"));
+    b_label.add_css_class("editor-color-field-label");
+    b_label.set_halign(gtk4::Align::Center);
+    b_label.set_xalign(0.5);
+    let b_col = GtkBox::new(Orientation::Vertical, 2);
+    b_col.set_halign(gtk4::Align::Fill);
+    b_col.set_hexpand(true);
+    b_col.append(&b_entry);
+    b_col.append(&b_label);
+    rgba_row.append(&b_col);
+
+    let a_entry = gtk4::Entry::new();
+    a_entry.set_max_length(3);
+    a_entry.set_width_chars(3);
+    a_entry.set_max_width_chars(3);
+    a_entry.set_halign(gtk4::Align::Fill);
+    a_entry.set_hexpand(true);
+    gtk4::prelude::EditableExt::set_alignment(&a_entry, 0.5);
+    a_entry.add_css_class("editor-rgba-entry");
+    let a_label = Label::new(Some("A"));
+    a_label.add_css_class("editor-color-field-label");
+    a_label.set_halign(gtk4::Align::Center);
+    a_label.set_xalign(0.5);
+    let a_col = GtkBox::new(Orientation::Vertical, 2);
+    a_col.set_halign(gtk4::Align::Fill);
+    a_col.set_hexpand(true);
+    a_col.append(&a_entry);
+    a_col.append(&a_label);
+    rgba_row.append(&a_col);
+
+    spectrum_section.append(&gradient_area);
+    spectrum_section.append(&hue_slider);
+    spectrum_section.append(&opacity_slider);
+    spectrum_section.append(&hex_row);
+    spectrum_section.append(&rgba_row);
+
+    let palette_section = GtkBox::new(Orientation::Vertical, 8);
+    palette_section.add_css_class("editor-colors-panel-section");
+    palette_section.set_hexpand(true);
+    palette_section.set_halign(gtk4::Align::Fill);
+
+    let palette_title = Label::new(Some("Palette"));
+    palette_title.add_css_class("editor-background-section-title");
+    palette_title.set_xalign(0.0);
+
+    let palette_grid = GtkBox::new(Orientation::Vertical, 6);
+    palette_grid.add_css_class("editor-colors-panel-palette-grid");
+    palette_grid.set_hexpand(true);
+    palette_grid.set_halign(gtk4::Align::Fill);
+
+    let palette_buttons: Vec<Button> = SIDEBAR_PALETTE_SPECS
+        .iter()
+        .map(|(tooltip, class_name)| color_swatch_button(class_name, tooltip))
+        .collect();
+
+    for row_index in 0..2 {
+        let row = GtkBox::new(Orientation::Horizontal, 6);
+        row.add_css_class("editor-colors-panel-palette-row");
+        row.set_homogeneous(true);
+        row.set_hexpand(true);
+        row.set_halign(gtk4::Align::Fill);
+
+        for column_index in 0..6 {
+            let index = row_index * 6 + column_index;
+            let button = palette_buttons[index].clone();
+            button.set_hexpand(true);
+            button.set_halign(gtk4::Align::Fill);
+            let apply_picker_color = apply_picker_color.clone();
+            button.connect_clicked(move |_| {
+                apply_picker_color(DRAW_COLORS[index]);
+            });
+            row.append(&button);
+        }
+
+        palette_grid.append(&row);
+    }
+
+    palette_section.append(&palette_title);
+    palette_section.append(&palette_grid);
+
+    let custom_section = GtkBox::new(Orientation::Vertical, 8);
+    custom_section.add_css_class("editor-colors-panel-section");
+    custom_section.set_hexpand(true);
+    custom_section.set_halign(gtk4::Align::Fill);
+
+    let custom_title = Label::new(Some("My colors"));
+    custom_title.add_css_class("editor-background-section-title");
+    custom_title.set_xalign(0.0);
+
+    let custom_grid = GtkBox::new(Orientation::Vertical, 6);
+    custom_grid.add_css_class("editor-colors-panel-custom-grid");
+    custom_grid.set_hexpand(true);
+    custom_grid.set_halign(gtk4::Align::Fill);
+
+    let custom_css_provider = CssProvider::new();
+    if let Some(display) = gdk::Display::default() {
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &custom_css_provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER,
+        );
+    }
+
+    let mut custom_slot_buttons = Vec::new();
+    let mut custom_slot_dots = Vec::new();
+    let mut custom_slot_placeholders = Vec::new();
+    let mut custom_slot_remove_buttons = Vec::new();
+
+    for row_index in 0..2 {
+        let row = GtkBox::new(Orientation::Horizontal, 6);
+        row.add_css_class("editor-colors-panel-custom-row");
+        row.set_homogeneous(true);
+        row.set_hexpand(true);
+        row.set_halign(gtk4::Align::Fill);
+
+        for column_index in 0..5 {
+            let index = row_index * 5 + column_index;
+            let slot_button = Button::new();
+            slot_button.set_has_frame(false);
+            slot_button.set_focusable(false);
+            slot_button.set_hexpand(true);
+            slot_button.set_halign(gtk4::Align::Fill);
+            slot_button.add_css_class("editor-color-button");
+            slot_button.add_css_class("editor-custom-color-slot");
+
+            let placeholder = GtkBox::new(Orientation::Horizontal, 0);
+            placeholder.set_size_request(18, 18);
+            placeholder.set_halign(gtk4::Align::Center);
+            placeholder.set_valign(gtk4::Align::Center);
+            placeholder.add_css_class("editor-color-placeholder-dot");
+
+            let custom_dot = GtkBox::new(Orientation::Horizontal, 0);
+            custom_dot.set_size_request(18, 18);
+            custom_dot.set_halign(gtk4::Align::Center);
+            custom_dot.set_valign(gtk4::Align::Center);
+            custom_dot.add_css_class("editor-color-dot");
+            custom_dot.set_widget_name(&format!("editor-sidebar-custom-color-dot-{index}"));
+
+            let remove_btn = Button::new();
+            remove_btn.set_has_frame(false);
+            remove_btn.set_focusable(false);
+            remove_btn.set_visible(false);
+            remove_btn.set_tooltip_text(Some("Remove custom color"));
+            remove_btn.set_halign(gtk4::Align::End);
+            remove_btn.set_valign(gtk4::Align::Start);
+            remove_btn.set_margin_top(-3);
+            remove_btn.set_margin_end(-3);
+            remove_btn.add_css_class("editor-custom-color-remove-button");
+            let remove_icon = gtk4::Image::from_icon_name(icon_names::DISMISS_REGULAR);
+            remove_icon.set_pixel_size(7);
+            remove_icon.add_css_class("editor-custom-color-remove-icon");
+            remove_btn.set_child(Some(&remove_icon));
+
+            slot_button.set_child(Some(&placeholder));
+
+            let overlay = Overlay::new();
+            overlay.add_css_class("editor-custom-color-slot-overlay");
+            overlay.set_hexpand(true);
+            overlay.set_halign(gtk4::Align::Fill);
+            overlay.set_child(Some(&slot_button));
+            overlay.add_overlay(&remove_btn);
+            row.append(&overlay);
+
+            let custom_slot_colors_click = custom_slot_colors.clone();
+            let apply_picker_color_click = apply_picker_color.clone();
+            slot_button.connect_clicked(move |_| {
+                if let Some(color) = custom_slot_colors_click.borrow()[index] {
+                    apply_picker_color_click(color);
+                }
+            });
+
+            let custom_slot_colors_remove = custom_slot_colors.clone();
+            let refresh_shared_custom_color_slots_remove = refresh_shared_custom_color_slots.clone();
+            remove_btn.connect_clicked(move |_| {
+                let mut custom_colors = custom_slot_colors_remove.borrow_mut();
+                if custom_colors[index].is_none() {
+                    return;
+                }
+
+                custom_colors[index] = None;
+                save_persisted_custom_slot_colors(custom_colors.as_slice());
+                drop(custom_colors);
+                refresh_shared_custom_color_slots_remove();
+            });
+
+            custom_slot_buttons.push(slot_button);
+            custom_slot_dots.push(custom_dot);
+            custom_slot_placeholders.push(placeholder);
+            custom_slot_remove_buttons.push(remove_btn);
+        }
+
+        custom_grid.append(&row);
+    }
+
+    custom_section.append(&custom_title);
+    custom_section.append(&custom_grid);
+
+    let actions = GtkBox::new(Orientation::Vertical, 8);
+    actions.add_css_class("editor-colors-panel-actions");
+    actions.set_halign(gtk4::Align::Fill);
+    actions.set_hexpand(true);
+
+    let add_current_color_btn = Button::with_label("+ Add current color");
+    add_current_color_btn.set_has_frame(false);
+    add_current_color_btn.set_halign(gtk4::Align::Fill);
+    add_current_color_btn.set_hexpand(true);
+    add_current_color_btn.add_css_class("editor-add-to-colors-button");
+    add_current_color_btn.add_css_class("editor-colors-panel-action-button");
+
+    let pick_from_screen_btn = Button::with_label("Pick from screen");
+    pick_from_screen_btn.set_has_frame(false);
+    pick_from_screen_btn.set_halign(gtk4::Align::Fill);
+    pick_from_screen_btn.set_hexpand(true);
+    pick_from_screen_btn.add_css_class("editor-colors-panel-action-button");
+
+    actions.append(&add_current_color_btn);
+    actions.append(&pick_from_screen_btn);
+
+    content.append(&helper);
+    content.append(&spectrum_section);
+    content.append(&palette_section);
+    content.append(&custom_section);
+    content.append(&actions);
+    root.append(&content);
+
+    let refresh_custom_slots: Rc<dyn Fn()> = Rc::new({
+        let custom_slot_colors = custom_slot_colors.clone();
+        let custom_slot_buttons = custom_slot_buttons.clone();
+        let custom_slot_dots = custom_slot_dots.clone();
+        let custom_slot_placeholders = custom_slot_placeholders.clone();
+        let custom_slot_remove_buttons = custom_slot_remove_buttons.clone();
+        let custom_css_provider = custom_css_provider.clone();
+        move || {
+            let custom_colors = custom_slot_colors.borrow();
+            let mut css = String::new();
+            for (index, slot_button) in custom_slot_buttons.iter().enumerate() {
+                if let Some(color) = custom_colors[index] {
+                    slot_button.add_css_class("has-custom-color");
+                    slot_button.set_child(Some(&custom_slot_dots[index]));
+                    custom_slot_remove_buttons[index].set_visible(true);
+
+                    let (r, g, b, _) = draw_color_to_rgba_u8(color);
+                    let alpha = color.a.clamp(0.0, 1.0);
+                    css.push_str(&format!(
+                        "#editor-sidebar-custom-color-dot-{index} {{ background: rgba({r}, {g}, {b}, {alpha:.3}); border: 1px solid rgba(0, 0, 0, 0.22); }}"
+                    ));
+                } else {
+                    slot_button.remove_css_class("has-custom-color");
+                    slot_button.set_child(Some(&custom_slot_placeholders[index]));
+                    custom_slot_remove_buttons[index].set_visible(false);
+                }
+            }
+            custom_css_provider.load_from_data(&css);
+        }
+    });
+
+    let apply_picker_state_color: Rc<dyn Fn()> = Rc::new({
+        let picker_state = picker_state.clone();
+        let apply_picker_color = apply_picker_color.clone();
+        move || {
+            let color = {
+                let picker = picker_state.borrow();
+                picker.to_color()
+            };
+            apply_picker_color(color);
+        }
+    });
+
+    let update_picker_ui: Rc<dyn Fn(PickerColorState)> = Rc::new({
+        let picker_update_in_progress = picker_update_in_progress.clone();
+        let gradient_area = gradient_area.clone();
+        let hue_slider = hue_slider.clone();
+        let opacity_slider = opacity_slider.clone();
+        let hex_entry = hex_entry.clone();
+        let r_entry = r_entry.clone();
+        let g_entry = g_entry.clone();
+        let b_entry = b_entry.clone();
+        let a_entry = a_entry.clone();
+        let picker_css_provider = picker_css_provider.clone();
+        move |picker| {
+            picker_update_in_progress.set(true);
+            hue_slider.set_value(picker.hue);
+            opacity_slider.set_value((picker.alpha * 100.0).clamp(0.0, 100.0));
+            let color = picker.to_color();
+            let (r, g, b, _): (u8, u8, u8, u8) = draw_color_to_rgba_u8(color);
+            hex_entry.set_text(&draw_color_to_hex(color));
+            r_entry.set_text(&r.to_string());
+            g_entry.set_text(&g.to_string());
+            b_entry.set_text(&b.to_string());
+            a_entry.set_text(&(picker.alpha * 100.0).round().to_string());
+            gradient_area.queue_draw();
+            let css = picker_dynamic_css(color)
+                .replace("#editor-picker-opacity-slider", "#editor-sidebar-picker-opacity-slider");
+            picker_css_provider.load_from_data(&css);
+            picker_update_in_progress.set(false);
+        }
+    });
+
+    let commit_picker_state: Rc<dyn Fn()> = Rc::new({
+        let picker_state = picker_state.clone();
+        let update_picker_ui = update_picker_ui.clone();
+        let apply_picker_state_color = apply_picker_state_color.clone();
+        move || {
+            let picker = *picker_state.borrow();
+            update_picker_ui(picker);
+            apply_picker_state_color();
+        }
+    });
+
+    hue_slider.connect_value_changed({
+        let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
+        let commit_picker_state = commit_picker_state.clone();
+        move |slider| {
+            if picker_update_in_progress.get() {
+                return;
+            }
+            picker_state.borrow_mut().hue = super::super::types::normalize_hue(slider.value());
+            commit_picker_state();
+        }
+    });
+
+    opacity_slider.connect_value_changed({
+        let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
+        let commit_picker_state = commit_picker_state.clone();
+        move |slider| {
+            if picker_update_in_progress.get() {
+                return;
+            }
+            picker_state.borrow_mut().alpha = (slider.value() / 100.0).clamp(0.0, 1.0);
+            commit_picker_state();
+        }
+    });
+
+    hex_entry.connect_changed({
+        let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
+        let commit_picker_state = commit_picker_state.clone();
+        move |entry| {
+            if picker_update_in_progress.get() {
+                return;
+            }
+
+            let text = entry.text();
+            let Some((r, g, b)) = parse_hex_rgb(text.as_str()) else {
+                return;
+            };
+            let (hue, saturation, value) =
+                super::super::types::rgb_to_hsv(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            {
+                let mut picker = picker_state.borrow_mut();
+                picker.hue = hue;
+                picker.saturation = saturation;
+                picker.value = value;
+            }
+            commit_picker_state();
+        }
+    });
+
+    let update_picker_from_rgba_entries: Rc<dyn Fn()> = Rc::new({
+        let picker_state = picker_state.clone();
+        let r_entry = r_entry.clone();
+        let g_entry = g_entry.clone();
+        let b_entry = b_entry.clone();
+        let a_entry = a_entry.clone();
+        let commit_picker_state = commit_picker_state.clone();
+        move || {
+            let Some(r) = parse_channel_u8(r_entry.text().as_str()) else {
+                return;
+            };
+            let Some(g) = parse_channel_u8(g_entry.text().as_str()) else {
+                return;
+            };
+            let Some(b) = parse_channel_u8(b_entry.text().as_str()) else {
+                return;
+            };
+            let Some(alpha) = parse_alpha_percent(a_entry.text().as_str()) else {
+                return;
+            };
+            let (hue, saturation, value) =
+                super::super::types::rgb_to_hsv(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            {
+                let mut picker = picker_state.borrow_mut();
+                picker.hue = hue;
+                picker.saturation = saturation;
+                picker.value = value;
+                picker.alpha = alpha;
+            }
+            commit_picker_state();
+        }
+    });
+
+    for entry in [&r_entry, &g_entry, &b_entry, &a_entry] {
+        let picker_update_in_progress = picker_update_in_progress.clone();
+        let update_picker_from_rgba_entries = update_picker_from_rgba_entries.clone();
+        entry.connect_changed(move |_| {
+            if picker_update_in_progress.get() {
+                return;
+            }
+            update_picker_from_rgba_entries();
+        });
+    }
+
+    let update_sv_from_position: Rc<dyn Fn(f64, f64)> = Rc::new({
+        let gradient_area = gradient_area.clone();
+        let picker_state = picker_state.clone();
+        let commit_picker_state = commit_picker_state.clone();
+        move |x, y| {
+            let width = gradient_area.allocated_width().max(1) as f64;
+            let height = gradient_area.allocated_height().max(1) as f64;
+            let saturation = (x / width).clamp(0.0, 1.0);
+            let value = (1.0 - (y / height)).clamp(0.0, 1.0);
+            {
+                let mut picker = picker_state.borrow_mut();
+                picker.saturation = saturation;
+                picker.value = value;
+            }
+            commit_picker_state();
+        }
+    });
+
+    let gradient_dragging = Rc::new(Cell::new(false));
+    let gradient_click = GestureClick::new();
+    {
+        let gradient_dragging = gradient_dragging.clone();
+        let update_sv_from_position = update_sv_from_position.clone();
+        gradient_click.connect_pressed(move |_, _, x, y| {
+            gradient_dragging.set(true);
+            update_sv_from_position(x, y);
+        });
+    }
+    {
+        let gradient_dragging = gradient_dragging.clone();
+        gradient_click.connect_released(move |_, _, _, _| {
+            gradient_dragging.set(false);
+        });
+    }
+    gradient_area.add_controller(gradient_click);
+
+    let gradient_motion = EventControllerMotion::new();
+    {
+        let gradient_dragging = gradient_dragging.clone();
+        let update_sv_from_position = update_sv_from_position.clone();
+        gradient_motion.connect_motion(move |_, x, y| {
+            if gradient_dragging.get() {
+                update_sv_from_position(x, y);
+            }
+        });
+    }
+    gradient_area.add_controller(gradient_motion);
+
+    let sync_for_active_tool: Rc<dyn Fn()> = Rc::new({
+        let state = state.clone();
+        let helper = helper.clone();
+        let palette_buttons = palette_buttons.clone();
+        let refresh_custom_slots = refresh_custom_slots.clone();
+        let picker_state = picker_state.clone();
+        let update_picker_ui = update_picker_ui.clone();
+        move || {
+            let (selected_tool, active_color) = {
+                let st = state.lock().unwrap();
+                let selected_tool = st.selected_tool;
+                let active_color = if selected_tool == Tool::Background {
+                    if let BackgroundStyle::PlainColor(color) = st.background_style {
+                        color
+                    } else {
+                        st.selected_color
+                    }
+                } else {
+                    st.selected_color
+                };
+                (selected_tool, active_color)
+            };
+
+            helper.set_label(if selected_tool == Tool::Background {
+                "Choose the solid color used when Background is set to plain color"
+            } else {
+                "Choose a color for the active tool"
+            });
+
+            set_active_color_button(&palette_buttons, palette_index_for_color(active_color));
+            let picker = PickerColorState::from_color(active_color);
+            *picker_state.borrow_mut() = picker;
+            update_picker_ui(picker);
+            refresh_custom_slots();
+        }
+    });
+
+    let state_add = state.clone();
+    let refresh_shared_custom_color_slots_add = refresh_shared_custom_color_slots.clone();
+    let sync_for_active_tool_add = sync_for_active_tool.clone();
+    add_current_color_btn.connect_clicked(move |_| {
+        let color_to_add = {
+            let st = state_add.lock().unwrap();
+            if st.selected_tool == Tool::Background {
+                if let BackgroundStyle::PlainColor(color) = st.background_style {
+                    color
+                } else {
+                    st.selected_color
+                }
+            } else {
+                st.selected_color
+            }
+        };
+
+        let mut custom_colors = custom_slot_colors.borrow_mut();
+        let Some(slot_index) = custom_colors.iter().position(Option::is_none) else {
+            return;
+        };
+
+        custom_colors[slot_index] = Some(color_to_add);
+        save_persisted_custom_slot_colors(custom_colors.as_slice());
+        drop(custom_colors);
+        refresh_shared_custom_color_slots_add();
+        sync_for_active_tool_add();
+    });
+
+    pick_from_screen_btn.connect_clicked(move |_| {
+        activate_eyedropper();
+    });
+
+    sync_for_active_tool();
+
+    ColorsPanelParts {
+        root,
+        sync_for_active_tool,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn colors_panel_contains_background_plain_color_apply_markers() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("BackgroundStyle::PlainColor")
+                && production_source.contains("selected_tool == Tool::Background"),
+            "Colors panel should support applying plain colors for the Background tool",
+        );
+    }
+
+    #[test]
+    fn colors_panel_contains_shared_color_management_markers() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("My colors")
+                && production_source.contains("+ Add current color")
+                && production_source.contains("Pick from screen")
+                && production_source.contains("let spectrum_section = GtkBox::new(Orientation::Vertical, 8);")
+                && production_source.contains("content.append(&spectrum_section);"),
+            "Colors panel should expose shared color management controls",
+        );
+    }
+
+    #[test]
+    fn colors_panel_embeds_compact_picker_fields_without_hue_preview_box() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            !production_source.contains("let hue_preview = GtkBox::new(Orientation::Horizontal, 0);")
+                && production_source.contains("let hex_entry = gtk4::Entry::new();")
+                && production_source.contains("let rgba_row = GtkBox::new(Orientation::Horizontal, 6);")
+                && production_source.contains("let r_entry = gtk4::Entry::new();")
+                && production_source.contains("let g_entry = gtk4::Entry::new();")
+                && production_source.contains("let b_entry = gtk4::Entry::new();")
+                && production_source.contains("let a_entry = gtk4::Entry::new();"),
+            "Colors panel should include compact HEX/RGBA fields and remove the hue preview box",
+        );
+    }
+
+    #[test]
+    fn colors_panel_gradient_area_no_longer_reflects_alpha_slider_visually() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            !production_source.contains("cr.push_group();")
+                && !production_source.contains("cr.paint_with_alpha(picker.alpha.clamp(0.0, 1.0));"),
+            "Colors panel gradient area should use the reverted opaque rendering path",
+        );
+    }
+
+    #[test]
+    fn colors_panel_no_longer_renders_current_color_summary_section() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            !production_source.contains("Current color")
+                && !production_source.contains("editor-colors-panel-current-row")
+                && !production_source.contains("editor-sidebar-current-color-preview"),
+            "Colors panel should not duplicate the current color summary once the toolbar owns that status",
+        );
+    }
+
+    #[test]
+    fn colors_panel_matches_background_content_width() {
+        let source = include_str!("colors_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && production_source.contains("root.set_hexpand(true);")
+                && production_source.contains("root.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("content.set_hexpand(true);")
+                && production_source.contains("content.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("palette_section.set_hexpand(true);")
+                && production_source.contains("palette_section.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("palette_grid.set_hexpand(true);")
+                && production_source.contains("palette_grid.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("button.set_hexpand(true);")
+                && production_source.contains("button.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("custom_section.set_hexpand(true);")
+                && production_source.contains("custom_section.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("custom_grid.set_hexpand(true);")
+                && production_source.contains("custom_grid.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("slot_button.set_hexpand(true);")
+                && production_source.contains("slot_button.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("overlay.set_hexpand(true);")
+                && production_source.contains("overlay.set_halign(gtk4::Align::Fill);")
+                && production_source.contains("let actions = GtkBox::new(Orientation::Vertical, 8);")
+                && production_source.contains("actions.set_hexpand(true);")
+                && production_source.contains("add_current_color_btn.set_hexpand(true);")
+                && production_source.contains("pick_from_screen_btn.set_hexpand(true);")
+                && !production_source.contains("palette_grid.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("custom_grid.set_width_request(BACKGROUND_SIDEBAR_WIDTH);"),
+            "Colors panel should use the same content width as the Background panel",
+        );
+    }
+}

--- a/src/capture/editor/window/colors_panel.rs
+++ b/src/capture/editor/window/colors_panel.rs
@@ -37,6 +37,7 @@ const SIDEBAR_PALETTE_SPECS: [(&str, &str); 12] = [
 pub struct ColorsPanelParts {
     pub root: GtkBox,
     pub sync_for_active_tool: Rc<dyn Fn()>,
+    pub refresh_custom_slots: Rc<dyn Fn()>,
 }
 
 pub fn build_colors_panel(
@@ -307,6 +308,9 @@ pub fn build_colors_panel(
     let mut custom_slot_placeholders = Vec::new();
     let mut custom_slot_remove_buttons = Vec::new();
 
+    // Placeholder for local refresh function, populated after refresh_custom_slots is created
+    let local_refresh: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+
     for row_index in 0..2 {
         let row = GtkBox::new(Orientation::Horizontal, 6);
         row.add_css_class("editor-colors-panel-custom-row");
@@ -360,6 +364,21 @@ pub fn build_colors_panel(
             overlay.set_halign(gtk4::Align::Fill);
             overlay.set_child(Some(&slot_button));
             overlay.add_overlay(&remove_btn);
+
+            let hover_controller = EventControllerMotion::new();
+            let remove_btn_enter = remove_btn.clone();
+            let custom_slot_colors_enter = custom_slot_colors.clone();
+            hover_controller.connect_enter(move |_, _, _| {
+                if custom_slot_colors_enter.borrow()[index].is_some() {
+                    remove_btn_enter.set_visible(true);
+                }
+            });
+            let remove_btn_leave = remove_btn.clone();
+            hover_controller.connect_leave(move |_| {
+                remove_btn_leave.set_visible(false);
+            });
+            overlay.add_controller(hover_controller);
+
             row.append(&overlay);
 
             let custom_slot_colors_click = custom_slot_colors.clone();
@@ -372,6 +391,7 @@ pub fn build_colors_panel(
 
             let custom_slot_colors_remove = custom_slot_colors.clone();
             let refresh_shared_custom_color_slots_remove = refresh_shared_custom_color_slots.clone();
+            let local_refresh_remove = local_refresh.clone();
             remove_btn.connect_clicked(move |_| {
                 let mut custom_colors = custom_slot_colors_remove.borrow_mut();
                 if custom_colors[index].is_none() {
@@ -382,6 +402,9 @@ pub fn build_colors_panel(
                 save_persisted_custom_slot_colors(custom_colors.as_slice());
                 drop(custom_colors);
                 refresh_shared_custom_color_slots_remove();
+                if let Some(refresh) = local_refresh_remove.borrow().as_ref() {
+                    refresh();
+                }
             });
 
             custom_slot_buttons.push(slot_button);
@@ -438,7 +461,7 @@ pub fn build_colors_panel(
                 if let Some(color) = custom_colors[index] {
                     slot_button.add_css_class("has-custom-color");
                     slot_button.set_child(Some(&custom_slot_dots[index]));
-                    custom_slot_remove_buttons[index].set_visible(true);
+                    custom_slot_remove_buttons[index].set_visible(false);
 
                     let (r, g, b, _) = draw_color_to_rgba_u8(color);
                     let alpha = color.a.clamp(0.0, 1.0);
@@ -454,6 +477,9 @@ pub fn build_colors_panel(
             custom_css_provider.load_from_data(&css);
         }
     });
+
+    // Populate the local refresh placeholder so remove buttons can call it
+    *local_refresh.borrow_mut() = Some(refresh_custom_slots.clone());
 
     let apply_picker_state_color: Rc<dyn Fn()> = Rc::new({
         let picker_state = picker_state.clone();
@@ -479,9 +505,14 @@ pub fn build_colors_panel(
         let a_entry = a_entry.clone();
         let picker_css_provider = picker_css_provider.clone();
         move |picker| {
+            let was_in_progress = picker_update_in_progress.get();
             picker_update_in_progress.set(true);
-            hue_slider.set_value(picker.hue);
-            opacity_slider.set_value((picker.alpha * 100.0).clamp(0.0, 100.0));
+            // Only set slider values if not already in a user interaction
+            // (sliders are already at the correct position during user interaction)
+            if !was_in_progress {
+                hue_slider.set_value(picker.hue);
+                opacity_slider.set_value((picker.alpha * 100.0).clamp(0.0, 100.0));
+            }
             let color = picker.to_color();
             let (r, g, b, _): (u8, u8, u8, u8) = draw_color_to_rgba_u8(color);
             hex_entry.set_text(&draw_color_to_hex(color));
@@ -493,7 +524,7 @@ pub fn build_colors_panel(
             let css = picker_dynamic_css(color)
                 .replace("#editor-picker-opacity-slider", "#editor-sidebar-picker-opacity-slider");
             picker_css_provider.load_from_data(&css);
-            picker_update_in_progress.set(false);
+            picker_update_in_progress.set(was_in_progress);
         }
     });
 
@@ -516,8 +547,10 @@ pub fn build_colors_panel(
             if picker_update_in_progress.get() {
                 return;
             }
+            picker_update_in_progress.set(true);
             picker_state.borrow_mut().hue = super::super::types::normalize_hue(slider.value());
             commit_picker_state();
+            picker_update_in_progress.set(false);
         }
     });
 
@@ -529,8 +562,10 @@ pub fn build_colors_panel(
             if picker_update_in_progress.get() {
                 return;
             }
+            picker_update_in_progress.set(true);
             picker_state.borrow_mut().alpha = (slider.value() / 100.0).clamp(0.0, 1.0);
             commit_picker_state();
+            picker_update_in_progress.set(false);
         }
     });
 
@@ -549,6 +584,7 @@ pub fn build_colors_panel(
             };
             let (hue, saturation, value) =
                 super::super::types::rgb_to_hsv(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            picker_update_in_progress.set(true);
             {
                 let mut picker = picker_state.borrow_mut();
                 picker.hue = hue;
@@ -556,11 +592,13 @@ pub fn build_colors_panel(
                 picker.value = value;
             }
             commit_picker_state();
+            picker_update_in_progress.set(false);
         }
     });
 
     let update_picker_from_rgba_entries: Rc<dyn Fn()> = Rc::new({
         let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
         let r_entry = r_entry.clone();
         let g_entry = g_entry.clone();
         let b_entry = b_entry.clone();
@@ -581,6 +619,7 @@ pub fn build_colors_panel(
             };
             let (hue, saturation, value) =
                 super::super::types::rgb_to_hsv(r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0);
+            picker_update_in_progress.set(true);
             {
                 let mut picker = picker_state.borrow_mut();
                 picker.hue = hue;
@@ -589,6 +628,7 @@ pub fn build_colors_panel(
                 picker.alpha = alpha;
             }
             commit_picker_state();
+            picker_update_in_progress.set(false);
         }
     });
 
@@ -606,18 +646,21 @@ pub fn build_colors_panel(
     let update_sv_from_position: Rc<dyn Fn(f64, f64)> = Rc::new({
         let gradient_area = gradient_area.clone();
         let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
         let commit_picker_state = commit_picker_state.clone();
         move |x, y| {
             let width = gradient_area.allocated_width().max(1) as f64;
             let height = gradient_area.allocated_height().max(1) as f64;
             let saturation = (x / width).clamp(0.0, 1.0);
             let value = (1.0 - (y / height)).clamp(0.0, 1.0);
+            picker_update_in_progress.set(true);
             {
                 let mut picker = picker_state.borrow_mut();
                 picker.saturation = saturation;
                 picker.value = value;
             }
             commit_picker_state();
+            picker_update_in_progress.set(false);
         }
     });
 
@@ -657,8 +700,15 @@ pub fn build_colors_panel(
         let palette_buttons = palette_buttons.clone();
         let refresh_custom_slots = refresh_custom_slots.clone();
         let picker_state = picker_state.clone();
+        let picker_update_in_progress = picker_update_in_progress.clone();
         let update_picker_ui = update_picker_ui.clone();
         move || {
+            // Don't reset picker state while we're in the middle of an update
+            // (e.g., dragging on the gradient area)
+            if picker_update_in_progress.get() {
+                return;
+            }
+
             let (selected_tool, active_color) = {
                 let st = state.lock().unwrap();
                 let selected_tool = st.selected_tool;
@@ -726,6 +776,7 @@ pub fn build_colors_panel(
     ColorsPanelParts {
         root,
         sync_for_active_tool,
+        refresh_custom_slots,
     }
 }
 

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -86,6 +86,7 @@ pub(super) struct EventContext {
     pub delete_selected_btn: Button,
     pub save_btn: Button,
     pub eyedropper_mode: Rc<Cell<bool>>,
+    pub eyedropper_from_sidebar: Rc<Cell<bool>>,
     pub eyedropper_point: Rc<RefCell<Option<Point>>>,
     pub eyedropper_rendered: Rc<RefCell<Option<RgbaImage>>>,
     pub canvas_eyedropper_ring: DrawingArea,
@@ -95,6 +96,7 @@ pub(super) struct EventContext {
     pub sync_picker_for_active_tool: Rc<dyn Fn()>,
     pub sync_picker_from_color: Rc<dyn Fn(DrawColor)>,
     pub apply_picker_color_to_editor: Rc<dyn Fn(DrawColor)>,
+    pub add_color_to_custom_slots: Rc<dyn Fn(DrawColor)>,
     pub set_picker_panel_visibility: Rc<dyn Fn(bool)>,
     pub sync_size_control: Rc<dyn Fn()>,
     pub rebuild_effects_async: Rc<dyn Fn()>,
@@ -159,6 +161,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         delete_selected_btn,
         save_btn,
         eyedropper_mode,
+        eyedropper_from_sidebar,
         eyedropper_point,
         eyedropper_rendered,
         canvas_eyedropper_ring,
@@ -168,6 +171,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         sync_picker_for_active_tool,
         sync_picker_from_color,
         apply_picker_color_to_editor,
+        add_color_to_custom_slots,
         set_picker_panel_visibility,
         sync_size_control,
         rebuild_effects_async,
@@ -1882,6 +1886,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let color_picker_dot_click = color_picker_dot.clone();
     let color_class_names_click = color_class_names.clone();
     let eyedropper_mode_click = eyedropper_mode.clone();
+    let eyedropper_from_sidebar_click = eyedropper_from_sidebar.clone();
     let eyedropper_point_click = eyedropper_point.clone();
     let eyedropper_rendered_click = eyedropper_rendered.clone();
     let color_popover_canvas_click = color_popover.clone();
@@ -1889,6 +1894,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let canvas_eyedropper_ring_click = canvas_eyedropper_ring.clone();
     let apply_picker_color_to_editor_canvas_click = apply_picker_color_to_editor.clone();
     let sync_picker_from_color_canvas_click = sync_picker_from_color.clone();
+    let add_color_to_custom_slots_click = add_color_to_custom_slots.clone();
     let sync_size_control_canvas_click = sync_size_control.clone();
     let text_size_label_click = text_size_label.clone();
     let font_family_label_click = font_family_label.clone();
@@ -2016,13 +2022,20 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
             };
 
             let mut reopen_color_popover = false;
+            let from_sidebar = eyedropper_from_sidebar_click.get();
             if let Some(color) = picked_color {
-                apply_picker_color_to_editor_canvas_click(color);
-                sync_picker_from_color_canvas_click(color);
-                reopen_color_popover = true;
+                // Only add to custom colors when picked from sidebar
+                add_color_to_custom_slots_click(color);
+                if !from_sidebar {
+                    // Only apply to editor and sync picker if not from sidebar
+                    apply_picker_color_to_editor_canvas_click(color);
+                    sync_picker_from_color_canvas_click(color);
+                    reopen_color_popover = true;
+                }
             }
 
             eyedropper_mode_click.set(false);
+            eyedropper_from_sidebar_click.set(false);
             *eyedropper_point_click.borrow_mut() = None;
             *eyedropper_rendered_click.borrow_mut() = None;
             canvas_eyedropper_ring_click.set_visible(false);

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -23,8 +23,8 @@ use super::render::{
 use super::selection::{action_bounds_with_padding, action_resize_handles};
 use super::state::{apply_effect_actions, EditorState};
 use super::types::{
-    AnnotationAction, BackgroundAlignment, BackgroundStyle, CropAspectRatio, EditorError, Point,
-    Rect, Tool, ViewTransform,
+    AnnotationAction, BackgroundAlignment, BackgroundStyle, CropAspectRatio, DrawColor,
+    EditorError, Point, Rect, Tool, ViewTransform,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -694,6 +694,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     );
     let colors_inspector = colors_panel_parts.root;
     let sync_colors_panel_for_active_tool = colors_panel_parts.sync_for_active_tool;
+    let refresh_colors_panel_custom_slots = colors_panel_parts.refresh_custom_slots;
     let toolbar_color_css_provider = gtk4::CssProvider::new();
     if let Some(display) = gdk::Display::default() {
         gtk4::style_context_add_provider_for_display(
@@ -985,6 +986,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     }
 
     let eyedropper_mode = Rc::new(Cell::new(false));
+    let eyedropper_from_sidebar = Rc::new(Cell::new(false));
     let eyedropper_point = Rc::new(RefCell::new(None::<Point>));
     let eyedropper_rendered = Rc::new(RefCell::new(None::<RgbaImage>));
 
@@ -992,12 +994,14 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         let color_popover = color_popover.clone();
         let state = state.clone();
         let eyedropper_mode = eyedropper_mode.clone();
+        let eyedropper_from_sidebar = eyedropper_from_sidebar.clone();
         let eyedropper_point = eyedropper_point.clone();
         let eyedropper_rendered = eyedropper_rendered.clone();
         let canvas_eyedropper_ring = canvas_eyedropper_ring.clone();
         let drawing_area = drawing_area.clone();
         let window = window.downgrade();
         move || {
+            eyedropper_from_sidebar.set(true);
             color_picker::activate_eyedropper(
                 &color_popover,
                 state.clone(),
@@ -2049,6 +2053,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         delete_selected_btn: delete_selected_btn.clone(),
         save_btn: save_btn.clone(),
         eyedropper_mode: eyedropper_mode.clone(),
+        eyedropper_from_sidebar: eyedropper_from_sidebar.clone(),
         eyedropper_point: eyedropper_point.clone(),
         eyedropper_rendered: eyedropper_rendered.clone(),
         canvas_eyedropper_ring: canvas_eyedropper_ring.clone(),
@@ -2058,6 +2063,21 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         sync_picker_for_active_tool: sync_shared_colors_for_active_tool.clone(),
         sync_picker_from_color: sync_picker_from_color.clone(),
         apply_picker_color_to_editor: apply_picker_color_to_editor.clone(),
+        add_color_to_custom_slots: Rc::new({
+            let custom_slot_colors = custom_slot_colors.clone();
+            let refresh_custom_color_slots = refresh_custom_color_slots.clone();
+            let refresh_colors_panel_custom_slots = refresh_colors_panel_custom_slots.clone();
+            move |color: DrawColor| {
+                let mut custom_colors = custom_slot_colors.borrow_mut();
+                if let Some(slot_index) = custom_colors.iter().position(Option::is_none) {
+                    custom_colors[slot_index] = Some(color);
+                    super::color::save_persisted_custom_slot_colors(custom_colors.as_slice());
+                    drop(custom_colors);
+                    refresh_custom_color_slots();
+                    refresh_colors_panel_custom_slots();
+                }
+            }
+        }),
         set_picker_panel_visibility: set_picker_panel_visibility.clone(),
         sync_size_control: sync_size_control.clone(),
         rebuild_effects_async: rebuild_effects_async.clone(),

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -1,4 +1,5 @@
 use gdk4x11::X11Surface;
+use gtk4::gdk;
 use gtk4::{
     glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation,
     Popover,
@@ -11,7 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use x11rb::{connection::Connection, protocol::xproto, protocol::xproto::ConnectionExt};
 
-use super::color::selection_hit_padding_for_scale;
+use super::color::{draw_color_to_hex, draw_color_to_rgba_u8, selection_hit_padding_for_scale};
 use super::render::{
     draw_active_text_input, draw_annotation_action, draw_arrow_control_handles,
     draw_arrow_selection_outline, draw_canvas_checkerboard_background, draw_crop_overlay,
@@ -57,6 +58,7 @@ use super::ui_support::{
 
 pub mod background_panel;
 mod canvas;
+pub mod colors_panel;
 pub mod color_picker;
 #[allow(dead_code)]
 mod cursor;
@@ -326,7 +328,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         drawing_area_placeholder.clone(),
         annotate_config.show_color_names,
     );
-    let color_picker_trigger_host = color_picker_parts.trigger_host;
+    let _color_picker_trigger_host = color_picker_parts.trigger_host;
     let color_popover = color_picker_parts.popover;
     let color_buttons = color_picker_parts.color_buttons;
     let color_picker_dot = color_picker_parts.color_picker_dot;
@@ -336,10 +338,17 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let sync_picker_from_color = color_picker_parts.sync_picker_from_color;
     let apply_picker_color_to_editor = color_picker_parts.apply_picker_color;
     let set_picker_panel_visibility = color_picker_parts.set_picker_panel_visibility;
+    let custom_slot_colors = color_picker_parts.custom_slot_colors;
+    let refresh_custom_color_slots = color_picker_parts.refresh_custom_color_slots;
+    let register_color_panel_sync = color_picker_parts.register_external_sync;
+    let sidebar_eyedropper_activation = Rc::new(RefCell::new(None::<Rc<dyn Fn()>>));
 
     let toolbar::ToolbarModeParts {
         root: center_group,
         toolbar_mode_stack,
+        color_status,
+        color_status_swatch,
+        color_status_label,
         size_group,
         size_slider,
         text_size_group,
@@ -395,11 +404,11 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &highlighter_btn,
         &sep_1,
         &sep_2,
-        &color_picker_trigger_host,
     );
     toolbar.set_center_widget(Some(&center_group));
 
     let toolbar_right_parts = toolbar::build_toolbar_right_controls(
+        &color_status,
         icon_names::ARROW_UNDO_REGULAR,
         icon_names::ARROW_REDO_REGULAR,
         icon_names::DELETE_REGULAR,
@@ -669,6 +678,70 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let start_background_gradient_preview_loading =
         background_panel_parts.start_gradient_preview_loading;
 
+    let colors_panel_parts = colors_panel::build_colors_panel(
+        state.clone(),
+        apply_picker_color_to_editor.clone(),
+        custom_slot_colors.clone(),
+        refresh_custom_color_slots.clone(),
+        Rc::new({
+            let sidebar_eyedropper_activation = sidebar_eyedropper_activation.clone();
+            move || {
+                if let Some(activate) = sidebar_eyedropper_activation.borrow().as_ref() {
+                    activate();
+                }
+            }
+        }),
+    );
+    let colors_inspector = colors_panel_parts.root;
+    let sync_colors_panel_for_active_tool = colors_panel_parts.sync_for_active_tool;
+    let toolbar_color_css_provider = gtk4::CssProvider::new();
+    if let Some(display) = gdk::Display::default() {
+        gtk4::style_context_add_provider_for_display(
+            &display,
+            &toolbar_color_css_provider,
+            gtk4::STYLE_PROVIDER_PRIORITY_USER,
+        );
+    }
+    let sync_toolbar_color_status: Rc<dyn Fn()> = Rc::new({
+        let state = state.clone();
+        let color_status_label = color_status_label.clone();
+        let _color_status_swatch = color_status_swatch.clone();
+        let toolbar_color_css_provider = toolbar_color_css_provider.clone();
+        move || {
+            let active_color = {
+                let st = state.lock().unwrap();
+                if st.selected_tool == Tool::Background {
+                    if let BackgroundStyle::PlainColor(color) = st.background_style {
+                        color
+                    } else {
+                        st.selected_color
+                    }
+                } else {
+                    st.selected_color
+                }
+            };
+
+            color_status_label.set_label(&format!("#{}", draw_color_to_hex(active_color)));
+            let (r, g, b, _) = draw_color_to_rgba_u8(active_color);
+            let alpha = active_color.a.clamp(0.0, 1.0);
+            let css = format!(
+                "#editor-toolbar-color-status-swatch {{ background: rgba({r}, {g}, {b}, {alpha:.3}); }}"
+            );
+            toolbar_color_css_provider.load_from_data(&css);
+        }
+    });
+    let sync_shared_colors_for_active_tool: Rc<dyn Fn()> = Rc::new({
+        let sync_toolbar_color_status = sync_toolbar_color_status.clone();
+        let sync_picker_for_active_tool = sync_picker_for_active_tool.clone();
+        let sync_colors_panel_for_active_tool = sync_colors_panel_for_active_tool.clone();
+        move || {
+            sync_toolbar_color_status();
+            sync_picker_for_active_tool();
+            sync_colors_panel_for_active_tool();
+        }
+    });
+    register_color_panel_sync(sync_shared_colors_for_active_tool.clone());
+
     let placeholder_inspector = GtkBox::new(Orientation::Vertical, 12);
     placeholder_inspector.add_css_class("editor-inspector-placeholder-shell");
     placeholder_inspector.set_vexpand(true);
@@ -685,12 +758,28 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     placeholder_inspector.append(&placeholder_title);
     placeholder_inspector.append(&placeholder);
 
+    let inspector_tabs = GtkBox::new(Orientation::Horizontal, 8);
+    inspector_tabs.add_css_class("editor-inspector-tabs");
+
+    let background_tab_btn = Button::with_label("Background");
+    background_tab_btn.set_has_frame(false);
+    background_tab_btn.add_css_class("editor-inspector-tab-button");
+
+    let colors_tab_btn = Button::with_label("Colors");
+    colors_tab_btn.set_has_frame(false);
+    colors_tab_btn.add_css_class("editor-inspector-tab-button");
+
+    inspector_tabs.append(&background_tab_btn);
+    inspector_tabs.append(&colors_tab_btn);
+
     let inspector = GtkBox::new(Orientation::Vertical, 0);
     inspector.add_css_class("editor-right-inspector");
     inspector.set_width_request(280);
     inspector.set_hexpand(false);
     inspector.set_vexpand(true);
+    inspector.append(&inspector_tabs);
     inspector.append(&background_inspector);
+    inspector.append(&colors_inspector);
     inspector.append(&placeholder_inspector);
 
     let workspace = GtkBox::new(Orientation::Horizontal, 0);
@@ -704,7 +793,11 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let update_toolbar_for_tool = toolbar::build_toolbar_tool_updater(
         &toolbar_mode_stack,
         &background_inspector,
+        &colors_inspector,
         &placeholder_inspector,
+        &inspector_tabs,
+        &background_tab_btn,
+        &colors_tab_btn,
         &text_size_group,
         &font_family_group,
         &obfuscate_method_group,
@@ -715,6 +808,68 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &canvas_scroller,
         start_background_gradient_preview_loading.clone(),
     );
+
+    let set_active_inspector_surface: Rc<dyn Fn(&str)> = Rc::new({
+        let background_inspector = background_inspector.clone();
+        let colors_inspector = colors_inspector.clone();
+        let placeholder_inspector = placeholder_inspector.clone();
+        let background_tab_btn = background_tab_btn.clone();
+        let colors_tab_btn = colors_tab_btn.clone();
+        move |surface| {
+            let show_background = surface == "background";
+            let show_colors = surface == "colors";
+            let show_placeholder = surface == "placeholder";
+            background_inspector.set_visible(show_background);
+            colors_inspector.set_visible(show_colors);
+            placeholder_inspector.set_visible(show_placeholder);
+            if show_background {
+                background_tab_btn.add_css_class("active-inspector-tab");
+            } else {
+                background_tab_btn.remove_css_class("active-inspector-tab");
+            }
+            if show_colors {
+                colors_tab_btn.add_css_class("active-inspector-tab");
+            } else {
+                colors_tab_btn.remove_css_class("active-inspector-tab");
+            }
+        }
+    });
+
+    background_tab_btn.connect_clicked({
+        let state = state.clone();
+        let set_active_inspector_surface = set_active_inspector_surface.clone();
+        move |_| {
+            if state.lock().unwrap().selected_tool == Tool::Background {
+                set_active_inspector_surface("background");
+            }
+        }
+    });
+
+    colors_tab_btn.connect_clicked({
+        let state = state.clone();
+        let set_active_inspector_surface = set_active_inspector_surface.clone();
+        let sync_colors_panel_for_active_tool = sync_colors_panel_for_active_tool.clone();
+        move |_| {
+            let selected_tool = state.lock().unwrap().selected_tool;
+            if matches!(
+                selected_tool,
+                Tool::Background
+                    | Tool::Pen
+                    | Tool::Arrow
+                    | Tool::Line
+                    | Tool::Box
+                    | Tool::Circle
+                    | Tool::Text
+                    | Tool::Number
+                    | Tool::Highlighter
+                    | Tool::Obfuscate
+                    | Tool::Focus
+            ) {
+                sync_colors_panel_for_active_tool();
+                set_active_inspector_surface("colors");
+            }
+        }
+    });
 
     let canvas_padding = canvas::CANVAS_PADDING;
 
@@ -832,6 +987,36 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let eyedropper_mode = Rc::new(Cell::new(false));
     let eyedropper_point = Rc::new(RefCell::new(None::<Point>));
     let eyedropper_rendered = Rc::new(RefCell::new(None::<RgbaImage>));
+
+    *sidebar_eyedropper_activation.borrow_mut() = Some(Rc::new({
+        let color_popover = color_popover.clone();
+        let state = state.clone();
+        let eyedropper_mode = eyedropper_mode.clone();
+        let eyedropper_point = eyedropper_point.clone();
+        let eyedropper_rendered = eyedropper_rendered.clone();
+        let canvas_eyedropper_ring = canvas_eyedropper_ring.clone();
+        let drawing_area = drawing_area.clone();
+        let window = window.downgrade();
+        move || {
+            color_picker::activate_eyedropper(
+                &color_popover,
+                state.clone(),
+                eyedropper_mode.clone(),
+                eyedropper_point.clone(),
+                eyedropper_rendered.clone(),
+                &canvas_eyedropper_ring,
+                &drawing_area,
+                Rc::new({
+                    let window = window.clone();
+                    move || {
+                        if let Some(window) = window.upgrade() {
+                            cursor::set_window_cursor_name(&window, Some("crosshair"));
+                        }
+                    }
+                }),
+            );
+        }
+    }));
 
     {
         let state_text_blink = state.clone();
@@ -1870,7 +2055,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         update_toolbar_for_tool: update_toolbar_for_tool.clone(),
         update_crop_size_fields: update_crop_size_fields.clone(),
         update_canvas_content_size: update_canvas_content_size.clone(),
-        sync_picker_for_active_tool: sync_picker_for_active_tool.clone(),
+        sync_picker_for_active_tool: sync_shared_colors_for_active_tool.clone(),
         sync_picker_from_color: sync_picker_from_color.clone(),
         apply_picker_color_to_editor: apply_picker_color_to_editor.clone(),
         set_picker_panel_visibility: set_picker_panel_visibility.clone(),
@@ -1912,6 +2097,33 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn toolbar_color_status_syncs_from_shared_active_color() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("editor-toolbar-color-status-swatch")
+                && production_source.contains("color_status_label.set_label")
+                && production_source.contains("BackgroundStyle::PlainColor")
+                && production_source.contains("draw_color_to_hex(active_color)"),
+            "Toolbar color status should mirror the shared active color, including Background plain color",
+        );
+    }
+
+    #[test]
+    fn toolbar_color_status_follows_colors_panel_palette_and_custom_color_updates() {
+        let mod_source = include_str!("mod.rs");
+        let mod_production_source = mod_source.split("#[cfg(test)]").next().unwrap_or(mod_source);
+        let colors_source = include_str!("colors_panel.rs");
+        let colors_production_source = colors_source.split("#[cfg(test)]").next().unwrap_or(colors_source);
+        assert!(
+            mod_production_source.contains("sync_toolbar_color_status();")
+                && colors_production_source.contains("apply_picker_color(DRAW_COLORS[index]);")
+                && colors_production_source.contains("apply_picker_color_click(color);"),
+            "Toolbar color status should follow palette and My colors selections from the Colors panel",
+        );
+    }
+
     #[test]
     fn editor_layout_includes_persistent_right_inspector_shell() {
         let source = include_str!("mod.rs");

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -1,6 +1,7 @@
 use gdk4x11::X11Surface;
 use gtk4::{
-    glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, Orientation, Popover,
+    glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation,
+    Popover,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
@@ -51,7 +52,7 @@ impl AnnotateRuntimeConfig {
 }
 use super::ui_support::{
     install_editor_css, prefers_dark_glass_theme, prefers_reduced_transparency,
-    recommended_window_size,
+    recommended_window_size_with_extra_width,
 };
 
 pub mod background_panel;
@@ -86,7 +87,7 @@ pub fn open_image_editor(path: PathBuf) -> Result<(), EditorError> {
     Ok(())
 }
 
-#[cfg(test)]
+#[allow(unused_imports)]
 pub(super) use cursor::cursor_name_for_view_point;
 
 fn env_var_contains_case_insensitive(key: &str, needle: &str) -> bool {
@@ -249,7 +250,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     )));
 
     let (default_width, default_height) =
-        recommended_window_size(img_width as i32, img_height as i32);
+        recommended_window_size_with_extra_width(img_width as i32, img_height as i32, 280);
 
     let window = ApplicationWindow::builder()
         .application(app)
@@ -664,25 +665,46 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &drawing_area,
         wallpaper_loader_sender,
     );
-    let background_sidebar = background_panel_parts.sidebar;
+    let background_inspector = background_panel_parts.root;
     let start_background_gradient_preview_loading =
         background_panel_parts.start_gradient_preview_loading;
 
-    // Re-parent sidebar into canvas workspace
-    if let Some(canvas_workspace) = canvas
-        .first_child()
-        .and_then(|c| c.downcast::<GtkBox>().ok())
-    {
-        if let Some(placeholder) = canvas_workspace.first_child() {
-            canvas_workspace.remove(&placeholder);
-        }
-        canvas_workspace.prepend(&background_sidebar);
-    }
+    let placeholder_inspector = GtkBox::new(Orientation::Vertical, 12);
+    placeholder_inspector.add_css_class("editor-inspector-placeholder-shell");
+    placeholder_inspector.set_vexpand(true);
+
+    let placeholder_title = Label::new(Some("Inspector"));
+    placeholder_title.add_css_class("editor-inspector-title");
+    placeholder_title.set_xalign(0.0);
+
+    let placeholder = Label::new(Some("Tool options coming soon"));
+    placeholder.add_css_class("editor-inspector-placeholder");
+    placeholder.set_wrap(true);
+    placeholder.set_xalign(0.0);
+
+    placeholder_inspector.append(&placeholder_title);
+    placeholder_inspector.append(&placeholder);
+
+    let inspector = GtkBox::new(Orientation::Vertical, 0);
+    inspector.add_css_class("editor-right-inspector");
+    inspector.set_width_request(280);
+    inspector.set_hexpand(false);
+    inspector.set_vexpand(true);
+    inspector.append(&background_inspector);
+    inspector.append(&placeholder_inspector);
+
+    let workspace = GtkBox::new(Orientation::Horizontal, 0);
+    workspace.set_hexpand(true);
+    workspace.set_vexpand(true);
+    workspace.append(&canvas);
+    workspace.append(&inspector);
+
     *drawing_area_placeholder.borrow_mut() = Some(drawing_area.downgrade());
 
     let update_toolbar_for_tool = toolbar::build_toolbar_tool_updater(
         &toolbar_mode_stack,
-        &background_sidebar,
+        &background_inspector,
+        &placeholder_inspector,
         &text_size_group,
         &font_family_group,
         &obfuscate_method_group,
@@ -692,9 +714,6 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &stroke_size_group,
         &canvas_scroller,
         start_background_gradient_preview_loading.clone(),
-        &window,
-        img_width as i32,
-        img_height as i32,
     );
 
     let canvas_padding = canvas::CANVAS_PADDING;
@@ -854,7 +873,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     });
 
     root.append(&toolbar);
-    root.append(&canvas);
+    root.append(&workspace);
     root.append(&footer_parts.root);
     window.set_child(Some(&root));
 
@@ -1078,6 +1097,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         }
     });
     sync_size_control();
+    update_toolbar_for_tool(Tool::Arrow);
 
     let state_draw = state.clone();
     let transform_draw = transform.clone();
@@ -1888,4 +1908,21 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         crate::gnome_integration::emit_tracked_window_closed(&tracked_window_id);
         glib::Propagation::Proceed
     });
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn editor_layout_includes_persistent_right_inspector_shell() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(production_source.contains("editor-right-inspector"));
+    }
+
+    #[test]
+    fn editor_layout_tracks_background_inspector_content() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(production_source.contains("background_inspector"));
+    }
 }

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -1,6 +1,6 @@
 use gtk4::{
-    prelude::*, ApplicationWindow, Box as GtkBox, Button, CenterBox, Entry, GestureClick, Image,
-    Label, MenuButton, Orientation, Overlay, Popover, Scale, Stack,
+    prelude::*, Box as GtkBox, Button, CenterBox, Entry, GestureClick, Image, Label,
+    MenuButton, Orientation, Overlay, Popover, Scale, Stack,
 };
 use std::rc::Rc;
 
@@ -8,12 +8,10 @@ use super::super::{
     pen_weight::PenWeight,
     types::{ArrowStyle, ObfuscateMethod, Tool},
     ui_support::{
-        arrow_style_toolbar_icon, icon_tool_button, recommended_window_size,
-        recommended_window_size_with_extra_width, tool_icon_widget, toolbar_icon_size,
+        arrow_style_toolbar_icon, icon_tool_button, tool_icon_widget, toolbar_icon_size,
         traffic_light_button,
     },
 };
-use super::background_panel::BACKGROUND_SIDEBAR_WIDTH;
 use super::icon_names;
 
 pub(super) struct ToolbarBaseParts {
@@ -1095,7 +1093,8 @@ pub(super) fn build_toolbar_right_controls(
 
 pub(super) fn build_toolbar_tool_updater(
     toolbar_mode_stack: &Stack,
-    background_sidebar: &GtkBox,
+    background_inspector: &GtkBox,
+    placeholder_inspector: &GtkBox,
     text_size_group: &GtkBox,
     font_family_group: &GtkBox,
     obfuscate_method_group: &GtkBox,
@@ -1105,12 +1104,10 @@ pub(super) fn build_toolbar_tool_updater(
     stroke_size_group: &GtkBox,
     canvas_scroller: &gtk4::ScrolledWindow,
     start_background_gradient_preview_loading: Rc<dyn Fn()>,
-    window: &ApplicationWindow,
-    image_width: i32,
-    image_height: i32,
 ) -> Rc<dyn Fn(Tool)> {
     let toolbar_mode_stack = toolbar_mode_stack.clone();
-    let background_sidebar = background_sidebar.clone();
+    let background_inspector = background_inspector.clone();
+    let placeholder_inspector = placeholder_inspector.clone();
     let text_size_group = text_size_group.clone();
     let font_family_group = font_family_group.clone();
     let obfuscate_method_group = obfuscate_method_group.clone();
@@ -1119,7 +1116,6 @@ pub(super) fn build_toolbar_tool_updater(
     let arrow_style_group = arrow_style_group.clone();
     let stroke_size_group = stroke_size_group.clone();
     let canvas_scroller = canvas_scroller.clone();
-    let window = window.downgrade();
 
     Rc::new(move |tool| {
         toolbar_mode_stack.set_visible_child_name(if matches!(tool, Tool::Crop) {
@@ -1147,7 +1143,6 @@ pub(super) fn build_toolbar_tool_updater(
         arrow_style_group.set_visible(is_arrow_tool);
         stroke_size_group.set_visible(is_arrow_tool || is_line_tool);
 
-        // Only allow vertical scrolling in Crop mode
         if matches!(tool, Tool::Crop) {
             canvas_scroller.set_policy(gtk4::PolicyType::Never, gtk4::PolicyType::Automatic);
         } else {
@@ -1155,26 +1150,11 @@ pub(super) fn build_toolbar_tool_updater(
         }
 
         let background_mode = matches!(tool, Tool::Background);
-        background_sidebar.set_visible(background_mode);
+        background_inspector.set_visible(background_mode);
+        placeholder_inspector.set_visible(!background_mode);
 
-        if let Some(window) = window.upgrade() {
-            if background_mode {
-                start_background_gradient_preview_loading();
-                let (target_width, target_height) = recommended_window_size_with_extra_width(
-                    image_width,
-                    image_height,
-                    BACKGROUND_SIDEBAR_WIDTH,
-                );
-                window.set_default_size(
-                    window.allocated_width().max(target_width),
-                    window.allocated_height().max(target_height),
-                );
-            } else {
-                // Return window to standard recommended size when sidebar is hidden
-                let (base_width, base_height) = recommended_window_size(image_width, image_height);
-                window.set_default_size(base_width, base_height);
-                window.queue_resize();
-            }
+        if background_mode {
+            start_background_gradient_preview_loading();
         }
     })
 }

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -71,6 +71,9 @@ pub(super) struct ToolbarRightParts {
 pub(super) struct ToolbarModeParts {
     pub root: GtkBox,
     pub toolbar_mode_stack: Stack,
+    pub color_status: GtkBox,
+    pub color_status_swatch: GtkBox,
+    pub color_status_label: Label,
     pub size_group: GtkBox,
     pub size_slider: gtk4::Scale,
     pub text_size_group: GtkBox,
@@ -576,11 +579,31 @@ pub(super) fn build_toolbar_mode_controls(
     highlighter_btn: &Button,
     sep_1: &GtkBox,
     sep_2: &GtkBox,
-    color_picker_trigger_host: &Overlay,
 ) -> ToolbarModeParts {
     let color_group = GtkBox::new(Orientation::Horizontal, 0);
     color_group.add_css_class("editor-color-group");
-    color_group.append(color_picker_trigger_host);
+
+    let color_status = GtkBox::new(Orientation::Horizontal, 8);
+    color_status.add_css_class("editor-toolbar-color-status");
+    color_status.set_valign(gtk4::Align::Center);
+
+    let color_status_swatch = GtkBox::new(Orientation::Horizontal, 0);
+    color_status_swatch.add_css_class("editor-toolbar-color-status-swatch");
+    color_status_swatch.set_widget_name("editor-toolbar-color-status-swatch");
+    color_status_swatch.set_size_request(30, 30);
+    color_status_swatch.set_halign(gtk4::Align::Center);
+    color_status_swatch.set_valign(gtk4::Align::Center);
+    color_status_swatch.set_hexpand(false);
+    color_status_swatch.set_vexpand(false);
+
+    let color_status_label = Label::new(Some("#121212"));
+    color_status_label.add_css_class("editor-toolbar-color-status-label");
+    color_status_label.set_xalign(0.0);
+    color_status_label.set_valign(gtk4::Align::Center);
+
+    color_status.append(&color_status_swatch);
+    color_status.append(&color_status_label);
+    color_group.append(&color_status);
 
     let size_slider = Scale::with_range(Orientation::Horizontal, 1.0, 24.0, 1.0);
     size_slider.add_css_class("editor-toolbar-size-slider");
@@ -988,11 +1011,12 @@ pub(super) fn build_toolbar_mode_controls(
     root.append(&toolbar_mode_stack);
     root.append(&text_size_group);
     root.append(&font_family_group);
-    root.append(&color_group);
-
     ToolbarModeParts {
         root,
         toolbar_mode_stack,
+        color_status,
+        color_status_swatch,
+        color_status_label,
         size_group,
         size_slider,
         text_size_group,
@@ -1035,6 +1059,7 @@ pub(super) fn build_toolbar_mode_controls(
 }
 
 pub(super) fn build_toolbar_right_controls(
+    color_status: &GtkBox,
     undo_icon_name: &str,
     redo_icon_name: &str,
     delete_icon_name: &str,
@@ -1055,6 +1080,7 @@ pub(super) fn build_toolbar_right_controls(
     let right_tools = GtkBox::new(Orientation::Horizontal, 12);
     right_tools.add_css_class("editor-toolbar-right-tools");
     right_tools.append(&history_group);
+    right_tools.append(color_status);
 
     let save_btn = Button::with_label("Done");
     save_btn.set_has_frame(false);
@@ -1094,7 +1120,11 @@ pub(super) fn build_toolbar_right_controls(
 pub(super) fn build_toolbar_tool_updater(
     toolbar_mode_stack: &Stack,
     background_inspector: &GtkBox,
+    colors_inspector: &GtkBox,
     placeholder_inspector: &GtkBox,
+    inspector_tabs: &GtkBox,
+    background_tab_btn: &Button,
+    colors_tab_btn: &Button,
     text_size_group: &GtkBox,
     font_family_group: &GtkBox,
     obfuscate_method_group: &GtkBox,
@@ -1107,7 +1137,11 @@ pub(super) fn build_toolbar_tool_updater(
 ) -> Rc<dyn Fn(Tool)> {
     let toolbar_mode_stack = toolbar_mode_stack.clone();
     let background_inspector = background_inspector.clone();
+    let colors_inspector = colors_inspector.clone();
     let placeholder_inspector = placeholder_inspector.clone();
+    let inspector_tabs = inspector_tabs.clone();
+    let background_tab_btn = background_tab_btn.clone();
+    let colors_tab_btn = colors_tab_btn.clone();
     let text_size_group = text_size_group.clone();
     let font_family_group = font_family_group.clone();
     let obfuscate_method_group = obfuscate_method_group.clone();
@@ -1150,11 +1184,121 @@ pub(super) fn build_toolbar_tool_updater(
         }
 
         let background_mode = matches!(tool, Tool::Background);
-        background_inspector.set_visible(background_mode);
-        placeholder_inspector.set_visible(!background_mode);
+        let colors_mode = matches!(
+            tool,
+            Tool::Background
+                | Tool::Pen
+                | Tool::Arrow
+                | Tool::Line
+                | Tool::Box
+                | Tool::Circle
+                | Tool::Text
+                | Tool::Number
+                | Tool::Highlighter
+                | Tool::Obfuscate
+                | Tool::Focus
+        );
+        background_tab_btn.set_label("Background");
+        colors_tab_btn.set_label("Colors");
+        inspector_tabs.set_visible(background_mode || colors_mode);
+        background_tab_btn.set_visible(background_mode);
+        colors_tab_btn.set_visible(colors_mode);
+
+        background_inspector.set_visible(false);
+        colors_inspector.set_visible(colors_mode);
+        placeholder_inspector.set_visible(!background_mode && !colors_mode);
+
+        if background_mode || colors_mode {
+            colors_inspector.set_visible(true);
+            colors_tab_btn.add_css_class("active-inspector-tab");
+            background_tab_btn.remove_css_class("active-inspector-tab");
+        } else {
+            background_tab_btn.remove_css_class("active-inspector-tab");
+            colors_tab_btn.remove_css_class("active-inspector-tab");
+        }
 
         if background_mode {
             start_background_gradient_preview_loading();
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn toolbar_uses_read_only_color_status_chip_instead_of_picker_trigger() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("editor-toolbar-color-status")
+                && production_source.contains("editor-toolbar-color-status-swatch")
+                && production_source.contains("editor-toolbar-color-status-label")
+                && !production_source.contains("color_picker_trigger_host"),
+            "Toolbar should use a read-only color status chip instead of the picker trigger host",
+        );
+    }
+
+    #[test]
+    fn toolbar_color_status_swatch_is_fixed_to_square_allocation() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("color_status_swatch.set_size_request(30, 30);")
+                && production_source.contains("color_status_swatch.set_halign(gtk4::Align::Center);")
+                && production_source.contains("color_status_swatch.set_valign(gtk4::Align::Center);")
+                && production_source.contains("color_status_swatch.set_hexpand(false);")
+                && production_source.contains("color_status_swatch.set_vexpand(false);"),
+            "Toolbar color swatch should keep a fixed boxed allocation so the shape is not stretched",
+        );
+    }
+
+    #[test]
+    fn toolbar_color_status_label_is_center_aligned_with_swatch() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("color_status.set_valign(gtk4::Align::Center);")
+                && production_source.contains("color_status_label.set_valign(gtk4::Align::Center);"),
+            "Toolbar color status label should align vertically with the swatch",
+        );
+    }
+
+    #[test]
+    fn toolbar_places_color_status_before_done_button_in_right_controls() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("pub(super) fn build_toolbar_right_controls(\n    color_status: &GtkBox,")
+                && production_source.contains("right_tools.append(color_status);")
+                && production_source.contains("root.append(&save_btn);"),
+            "Toolbar should place the color status in the right controls before the Done button",
+        );
+    }
+
+    #[test]
+    fn color_capable_tools_default_to_colors_inspector_surface() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("background_inspector.set_visible(false);")
+                && production_source.contains("colors_inspector.set_visible(colors_mode);")
+                && production_source.contains("Tool::Background")
+                && production_source.contains("Tool::Pen")
+                && production_source.contains("Tool::Focus"),
+            "Color-capable tools should switch the right inspector to the Colors surface",
+        );
+    }
+
+    #[test]
+    fn background_and_color_tools_route_into_shared_colors_inspector() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("Tool::Background")
+                && production_source.contains("Tool::Pen")
+                && production_source.contains("Tool::Highlighter")
+                && production_source.contains("\"Colors\""),
+            "Toolbar inspector routing should include Background and color-capable tools in the shared Colors flow",
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Reduce slider thickness for better visual appearance in colors panel
- Style remove button for custom colors with red background and white X icon
- Add hover controller to show/hide remove button on custom color slots
- Fix realtime refresh when adding/removing custom colors
- Auto-add picked colors to My Colors when using sidebar eyedropper
- Prevent popover popup when eyedropper is activated from sidebar
- Fix color picker state jumping when dragging on gradient area or hue slider
- Improve eyedropper loupe rendering with crisp pixel edges
- Fix external sync to properly sync colors panel with editor state

## Test plan
- [ ] Verify sliders in colors panel are properly sized
- [ ] Test remove button on custom colors shows/hides on hover
- [ ] Verify picked colors are auto-added to My Colors
- [ ] Test gradient area and hue slider don't jump when dragging
- [ ] Verify eyedropper loupe has crisp pixel edges
- [ ] Test all color picker interactions work correctly