### PR TITLE
feat: migrate annotate tool controls into the right inspector

### DIFF
--- a/docs/superpowers/plans/2026-04-07-right-inspector-arrow-panel-sections.md
+++ b/docs/superpowers/plans/2026-04-07-right-inspector-arrow-panel-sections.md
@@ -1,0 +1,301 @@
+# Right Inspector Arrow Panel Sections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the Arrow inspector tab into three direct sections, `Style`, `Thickness`, and `Behavior`, using existing Arrow hooks and keeping the inspector width unchanged.
+
+**Architecture:** Keep the existing inspector shell and `Arrow | Colors` routing in `window/mod.rs`, but build the Arrow primary surface as a dedicated inspector-native panel instead of a reused toolbar dropdown shell. Reuse the existing Arrow style and stroke-size state hooks, and add a `Behavior` section only if it can map to the existing `inverse_arrow_direction` path without introducing new Arrow state or render logic.
+
+**Tech Stack:** Rust, GTK4, existing annotate editor window modules, source-level regression tests with `include_str!`, `cargo test`, `cargo check`
+
+---
+
+## File map
+
+- Modify: `src/capture/editor/window/mod.rs` — Arrow inspector layout, direct section builders, source regression tests
+- Modify: `src/capture/editor/window/events.rs` — wire the Arrow inspector section widgets into existing Arrow state hooks
+- Modify: `src/capture/editor/window/toolbar.rs` — keep only the shared line/arrow stroke toolbar surface where still needed, update source regression tests if layout markers change
+- Modify: `src/capture/editor/ui_support.rs` — inspector section/list styling for the Arrow panel
+- Test: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+Width constraint:
+- keep using the existing fixed inspector width path
+- do not add any Arrow-specific width constants or alternate panel widths
+
+### Task 1: Add failing regression tests for Arrow panel sections
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/mod.rs`
+
+- [ ] **Step 1: Add a failing source test for the three Arrow sections**
+
+Add this test in `src/capture/editor/window/mod.rs` near the existing inspector tests:
+
+```rust
+#[test]
+fn arrow_inspector_includes_style_thickness_and_behavior_sections() {
+    let source = include_str!("mod.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("append_inspector_section(&arrow_inspector_content, \"Style\"")
+            && production_source.contains("append_inspector_section(&arrow_inspector_content, \"Thickness\"")
+            && production_source.contains("append_inspector_section(&arrow_inspector_content, \"Behavior\""),
+        "Arrow inspector should render Style, Thickness, and Behavior sections",
+    );
+}
+```
+
+- [ ] **Step 2: Add a failing source test for width reuse**
+
+Add this companion test in `src/capture/editor/window/mod.rs`:
+
+```rust
+#[test]
+fn arrow_inspector_reuses_existing_fixed_sidebar_width() {
+    let source = include_str!("mod.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+            && !production_source.contains("ARROW_SIDEBAR_WIDTH"),
+        "Arrow inspector should reuse the shared fixed sidebar width instead of introducing a new width path",
+    );
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test arrow_inspector_includes_style_thickness_and_behavior_sections --lib
+cargo test arrow_inspector_reuses_existing_fixed_sidebar_width --lib
+```
+
+Expected: the section test fails until `Thickness` and `Behavior` are added; the width test may already pass if the current builder still reuses `BACKGROUND_SIDEBAR_WIDTH`.
+
+- [ ] **Step 4: Commit the regression tests**
+
+```bash
+git add src/capture/editor/window/mod.rs
+git commit -m "test: add Arrow inspector section regression coverage"
+```
+
+### Task 2: Build the Arrow inspector as a dedicated three-section panel
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/ui_support.rs`
+
+- [ ] **Step 1: Replace the current Arrow panel body with three direct sections**
+
+In `src/capture/editor/window/mod.rs`, keep the existing Arrow inspector surface, but structure it as:
+
+```rust
+let (arrow_inspector, arrow_inspector_content) = build_tool_inspector();
+append_inspector_section(&arrow_inspector_content, "Style", arrow_style_list.upcast_ref());
+append_inspector_section(&arrow_inspector_content, "Thickness", arrow_thickness_list.upcast_ref());
+append_inspector_section(&arrow_inspector_content, "Behavior", arrow_behavior_group.upcast_ref());
+```
+
+Use fresh Arrow inspector-native widget trees for all three sections instead of toolbar trigger buttons.
+
+- [ ] **Step 2: Build a direct `Thickness` list for Arrow**
+
+Create an Arrow-only thickness list in `src/capture/editor/window/mod.rs` using the same four existing stroke sizes:
+
+```rust
+let arrow_thickness_list = GtkBox::new(Orientation::Vertical, 0);
+for (label, _size, weight) in [
+    ("Thin", 2.0_f64, PenWeight::Small),
+    ("Medium", 4.0_f64, PenWeight::Medium),
+    ("Thick", 7.0_f64, PenWeight::Large),
+    ("Very Thick", 12.0_f64, PenWeight::ExtraLarge),
+] {
+    // build sidebar-native button rows
+}
+```
+
+This list is Arrow-only for the inspector even though the underlying stroke-size state is shared with Line.
+
+- [ ] **Step 3: Build an Arrow `Behavior` section only from existing hooks**
+
+Create a compact `Behavior` group in `src/capture/editor/window/mod.rs` with a single existing-hook candidate:
+
+```rust
+let arrow_behavior_group = GtkBox::new(Orientation::Vertical, 8);
+let inverse_direction_toggle = gtk4::CheckButton::with_label("Reverse direction");
+arrow_behavior_group.append(&inverse_direction_toggle);
+```
+
+Do not add any other behavior rows unless they map directly to already-supported Arrow state/config.
+
+- [ ] **Step 4: Add minimal inspector styling**
+
+In `src/capture/editor/ui_support.rs`, add or adjust classes for:
+
+```css
+.editor-inspector-section
+.editor-inspector-section-body
+.editor-inspector-option-list
+.editor-inspector-toggle-row
+```
+
+Keep them within the existing fixed-width panel and avoid any new width rules beyond the shared sidebar path.
+
+- [ ] **Step 5: Run the section tests and compile check**
+
+Run:
+
+```bash
+cargo test arrow_inspector_includes_style_thickness_and_behavior_sections --lib
+cargo test arrow_inspector_reuses_existing_fixed_sidebar_width --lib
+cargo check
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the Arrow panel structure**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/ui_support.rs
+git commit -m "feat: add Arrow inspector style thickness and behavior sections"
+```
+
+### Task 3: Wire Arrow thickness and behavior to existing state hooks
+
+**Files:**
+- Modify: `src/capture/editor/window/events.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+
+- [ ] **Step 1: Wire the Arrow thickness list to the existing stroke-size hook**
+
+In `src/capture/editor/window/events.rs`, add a dedicated loop for the new Arrow inspector thickness list that mirrors the existing stroke-size button wiring:
+
+```rust
+let arrow_thickness_sizes: [(f64, PenWeight); 4] = [
+    (2.0, PenWeight::Small),
+    (4.0, PenWeight::Medium),
+    (7.0, PenWeight::Large),
+    (12.0, PenWeight::ExtraLarge),
+];
+```
+
+Each row should call:
+
+```rust
+st.set_stroke_size(size);
+```
+
+and then queue a redraw.
+
+- [ ] **Step 2: Wire the Arrow behavior toggle only if it maps to existing state**
+
+If the current editor already exposes `inverse_arrow_direction` as mutable runtime state, wire the new `Reverse direction` toggle to that path:
+
+```rust
+inverse_direction_toggle.connect_toggled({
+    let state = state.clone();
+    let drawing_area = drawing_area.downgrade();
+    move |toggle| {
+        {
+            let mut st = state.lock().unwrap();
+            st.inverse_arrow_direction = toggle.is_active();
+        }
+        if let Some(area) = drawing_area.upgrade() {
+            area.queue_draw();
+        }
+    }
+});
+```
+
+If runtime mutation is not already a supported path, stop here and keep `Behavior` out of implementation rather than inventing a new model.
+
+- [ ] **Step 3: Sync the `Behavior` control from current state**
+
+Add a small sync closure in `src/capture/editor/window/mod.rs` so the Arrow behavior toggle reflects current editor state when Arrow becomes active:
+
+```rust
+let sync_arrow_behavior_controls: Rc<dyn Fn()> = Rc::new({
+    let state = state.clone();
+    let inverse_direction_toggle = inverse_direction_toggle.clone();
+    move || {
+        let st = state.lock().unwrap();
+        inverse_direction_toggle.set_active(st.inverse_arrow_direction);
+    }
+});
+```
+
+Call that sync from the Arrow tool routing path before the Arrow panel becomes visible.
+
+- [ ] **Step 4: Run focused verification**
+
+Run:
+
+```bash
+cargo test capture::editor::window --lib
+cargo check
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the Arrow hook wiring**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/events.rs
+git commit -m "feat: wire Arrow inspector thickness and behavior controls"
+```
+
+### Task 4: Final verification for Arrow-only panel completion
+
+**Files:**
+- Modify: none unless verification exposes a bug
+
+- [ ] **Step 1: Run the final automated verification**
+
+Run:
+
+```bash
+cargo test capture::editor::window --lib
+cargo check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run manual Arrow verification**
+
+Open the annotate editor and verify:
+
+```text
+1. Select Arrow and confirm the primary tab shows Style, Thickness, and Behavior sections.
+2. Change Arrow style and confirm new arrows use the selected style.
+3. Change Arrow thickness and confirm new arrows use the selected thickness.
+4. Toggle Reverse direction, if included, and confirm the Arrow behavior changes immediately.
+5. Switch to Colors and back to Arrow and confirm the panel state stays coherent.
+6. Confirm the panel width is unchanged from the existing inspector width.
+7. Confirm Text, Number, and Background panels still render within the same sidebar shell.
+```
+
+- [ ] **Step 3: Commit the verified Arrow panel slice**
+
+```bash
+git add -A
+git commit -m "feat: finish Arrow inspector panel sections"
+```
+
+## Self-review
+
+Spec coverage:
+- Arrow-only scope is covered by Tasks 2 through 4
+- `Style`, `Thickness`, and `Behavior` sections are covered by Tasks 1 and 2
+- behavior limited to existing hooks is enforced in Task 3
+- unchanged width is covered by Tasks 1, 2, and 4
+
+Placeholder scan:
+- no `TODO` or `TBD` placeholders remain
+- each task names exact files and commands
+
+Type consistency:
+- the plan consistently refers to `arrow_thickness_list`, `arrow_behavior_group`, and `inverse_direction_toggle`
+- `Behavior` is consistently limited to existing Arrow hooks only

--- a/docs/superpowers/plans/2026-04-07-right-inspector-arrow-text-number.md
+++ b/docs/superpowers/plans/2026-04-07-right-inspector-arrow-text-number.md
@@ -1,0 +1,359 @@
+# Right Inspector Arrow Text Number Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `Arrow`, `Text`, and `Number` sub-tool controls from the annotate toolbar into the persistent right inspector while preserving the shared `Colors` tab behavior.
+
+**Architecture:** Keep the existing right-inspector shell in `window/mod.rs`, add a focused tool-panels module for the migrated primary tabs, and reuse the same editor-state callbacks the toolbar controls already use today. The toolbar remains the place for tool selection and global actions, while the inspector becomes the home for detailed per-tool settings. The inspector width must remain exactly as it is today for every tool surface; this migration reuses the current sidebar width instead of introducing tool-specific sizing.
+
+**Tech Stack:** Rust, GTK4, existing annotate editor window modules, source-level regression tests with `include_str!`, `cargo test`, `cargo check`
+
+---
+
+## File map
+
+- Create: `src/capture/editor/window/tool_panels.rs` — reusable right-inspector builders for `Arrow`, `Text`, and `Number`
+- Modify: `src/capture/editor/window/mod.rs` — inspector routing, tab labels, tool-panel mounting, callback wiring, source regression tests
+- Modify: `src/capture/editor/window/toolbar.rs` — remove migrated toolbar groups from visible tool surfaces, keep shared/global controls, source regression tests
+- Modify: `src/capture/editor/window/events.rs` — if any moved controls still rely on toolbar-local signal wiring, expose or reuse the same callbacks from inspector widgets
+- Modify: `src/capture/editor/ui_support.rs` — sidebar styling helpers if the moved controls need inspector-specific classes
+- Test: `src/capture/editor/window/mod.rs` and `src/capture/editor/window/toolbar.rs` source-level regression tests
+
+Width constraint:
+- reuse the current inspector width defined by `BACKGROUND_SIDEBAR_WIDTH`
+- do not add per-tool width requests, width calculations, or wider/narrower variants for `Arrow`, `Text`, or `Number`
+- all migrated inspector panels must render inside the same fixed-width shell the Background panel already uses
+
+### Task 1: Add failing regression tests for inspector routing and toolbar decluttering
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/window/toolbar.rs`
+- Test: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Add a failing source test for `Arrow`, `Text`, and `Number` inspector routing**
+
+Add this test near the existing `#[cfg(test)]` block in `src/capture/editor/window/mod.rs`:
+
+```rust
+#[test]
+fn arrow_text_and_number_route_to_tool_specific_inspector_tabs() {
+    let source = include_str!("mod.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        production_source.contains("Tool::Arrow")
+            && production_source.contains("Tool::Text")
+            && production_source.contains("Tool::Number")
+            && production_source.contains("\"arrow\"")
+            && production_source.contains("\"text\"")
+            && production_source.contains("\"number\"")
+            && production_source.contains("\"colors\""),
+        "Inspector routing should expose Arrow, Text, and Number primary panels alongside the shared Colors surface",
+    );
+}
+```
+
+- [ ] **Step 2: Add a failing source test for toolbar cleanup markers**
+
+Add this test near the existing `#[cfg(test)]` block in `src/capture/editor/window/toolbar.rs`:
+
+```rust
+#[test]
+fn toolbar_no_longer_exposes_arrow_text_and_number_detail_groups() {
+    let source = include_str!("toolbar.rs");
+    let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+    assert!(
+        !production_source.contains("text_size_group.set_visible(true)")
+            && !production_source.contains("font_family_group.set_visible(true)")
+            && !production_source.contains("number_options_group.set_visible(true)")
+            && !production_source.contains("arrow_style_group.set_visible(true)"),
+        "Toolbar tool-updater should stop making Arrow, Text, and Number detail groups visible after the inspector migration",
+    );
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test arrow_text_and_number_route_to_tool_specific_inspector_tabs toolbar_no_longer_exposes_arrow_text_and_number_detail_groups --lib
+```
+
+Expected: FAIL because the current inspector still routes those tools through the placeholder or colors-only flow and the toolbar still toggles the migrated groups.
+
+- [ ] **Step 4: Commit the failing-test checkpoint**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/toolbar.rs
+git commit -m "test: add right inspector migration regression coverage"
+```
+
+### Task 2: Create dedicated inspector panels for `Arrow`, `Text`, and `Number`
+
+**Files:**
+- Create: `src/capture/editor/window/tool_panels.rs`
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/ui_support.rs`
+
+- [ ] **Step 1: Create a focused tool-panels module**
+
+Create `src/capture/editor/window/tool_panels.rs` with a small public surface:
+
+```rust
+use gtk4::prelude::*;
+use gtk4::{Box as GtkBox, Button, Label, Orientation, Popover, Scale};
+
+pub struct ArrowPanelParts {
+    pub root: GtkBox,
+    pub arrow_style_list: GtkBox,
+    pub stroke_size_list: GtkBox,
+}
+
+pub struct TextPanelParts {
+    pub root: GtkBox,
+    pub text_size_list: GtkBox,
+    pub font_family_list: GtkBox,
+}
+
+pub struct NumberPanelParts {
+    pub root: GtkBox,
+    pub number_options_list: GtkBox,
+    pub number_size_list: GtkBox,
+    pub number_start_entry: gtk4::Entry,
+    pub number_inc_btn: Button,
+    pub number_dec_btn: Button,
+}
+```
+
+- [ ] **Step 2: Build vertical inspector variants of the migrated controls**
+
+In `src/capture/editor/window/tool_panels.rs`, add builder functions that keep the existing control semantics but render them in a right-sidebar layout:
+
+```rust
+pub fn build_arrow_panel() -> ArrowPanelParts { /* section title + style list + stroke list */ }
+
+pub fn build_text_panel() -> TextPanelParts { /* section title + text size list + font family list */ }
+
+pub fn build_number_panel() -> NumberPanelParts { /* section title + style list + start controls + size list */ }
+```
+
+Use the same option labels and CSS class names already present in `toolbar.rs` wherever practical so existing signal hookup code can be reused.
+Set the new panel roots to the same fixed width as the existing inspector shell instead of introducing new width values.
+
+- [ ] **Step 3: Export the new module from `window/mod.rs`**
+
+Add the module declaration beside the existing inspector modules:
+
+```rust
+pub mod background_panel;
+pub mod colors_panel;
+mod tool_panels;
+mod toolbar;
+```
+
+- [ ] **Step 4: Run a compile check**
+
+Run:
+
+```bash
+cargo check
+```
+
+Expected: PASS, with the new module compiling even if it is not yet fully wired into the runtime inspector flow.
+
+- [ ] **Step 5: Commit the new panel module**
+
+```bash
+git add src/capture/editor/window/tool_panels.rs src/capture/editor/window/mod.rs src/capture/editor/ui_support.rs
+git commit -m "feat: add right inspector panels for arrow text and number"
+```
+
+### Task 3: Mount the new tool panels into the inspector shell and route each tool to its primary tab
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Test: `src/capture/editor/window/mod.rs`
+
+- [ ] **Step 1: Replace the placeholder-only flow for these tools with named inspector surfaces**
+
+In `src/capture/editor/window/mod.rs`, build and register the new panels next to the existing background and colors surfaces:
+
+```rust
+let arrow_inspector = tool_panels::build_arrow_panel();
+let text_inspector = tool_panels::build_text_panel();
+let number_inspector = tool_panels::build_number_panel();
+
+inspector_stack.add_named(&arrow_inspector.root, Some("arrow"));
+inspector_stack.add_named(&text_inspector.root, Some("text"));
+inspector_stack.add_named(&number_inspector.root, Some("number"));
+```
+
+- [ ] **Step 2: Add a helper that updates the primary tab label and target surface**
+
+Replace the fixed `Background` tab assumption with a small routing helper:
+
+```rust
+let set_primary_inspector_tab: Rc<dyn Fn(&str, &str)> = Rc::new({
+    let background_tab_btn = background_tab_btn.clone();
+    move |label, surface| {
+        background_tab_btn.set_label(label);
+        background_tab_btn.set_widget_name(surface);
+    }
+});
+```
+
+Then use it inside the tool-selection routing so:
+- `Tool::Background` maps to label `Background` + surface `"background"`
+- `Tool::Arrow` maps to label `Arrow` + surface `"arrow"`
+- `Tool::Text` maps to label `Text` + surface `"text"`
+- `Tool::Number` maps to label `Number` + surface `"number"`
+
+- [ ] **Step 3: Default each migrated tool back to its primary tab**
+
+Update the tool-change path so selecting `Arrow`, `Text`, or `Number` calls:
+
+```rust
+set_primary_inspector_tab("Arrow", "arrow");
+set_active_inspector_surface("arrow");
+```
+
+and the corresponding `Text` / `Number` equivalents before any colors-panel sync runs.
+
+- [ ] **Step 4: Re-run the routing test**
+
+Run:
+
+```bash
+cargo test arrow_text_and_number_route_to_tool_specific_inspector_tabs --lib
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the routing work**
+
+```bash
+git add src/capture/editor/window/mod.rs
+git commit -m "feat: route arrow text and number into right inspector tabs"
+```
+
+### Task 4: Rewire the moved controls to existing editor state and remove the detailed toolbar groups
+
+**Files:**
+- Modify: `src/capture/editor/window/mod.rs`
+- Modify: `src/capture/editor/window/toolbar.rs`
+- Modify: `src/capture/editor/window/events.rs`
+- Test: `src/capture/editor/window/toolbar.rs`
+
+- [ ] **Step 1: Reuse the existing control hookup logic with inspector-owned widgets**
+
+Where `mod.rs` currently wires callbacks to `text_size_list`, `font_family_list`, `number_options_list`, `number_size_list`, `number_start_entry`, `arrow_style_list`, and `stroke_size_list`, switch those references to the corresponding fields from `tool_panels.rs`:
+
+```rust
+let arrow_panel = tool_panels::build_arrow_panel();
+let text_panel = tool_panels::build_text_panel();
+let number_panel = tool_panels::build_number_panel();
+
+let arrow_style_list = arrow_panel.arrow_style_list.clone();
+let text_size_list = text_panel.text_size_list.clone();
+let font_family_list = text_panel.font_family_list.clone();
+let number_options_list = number_panel.number_options_list.clone();
+```
+
+Keep the underlying state updates unchanged so the migration only changes the render location.
+
+- [ ] **Step 2: Stop the toolbar updater from exposing the migrated groups**
+
+In `src/capture/editor/window/toolbar.rs`, remove `Arrow`, `Text`, and `Number` from the visibility toggles in `build_toolbar_tool_updater(...)` so the toolbar no longer activates:
+
+```rust
+text_size_group.set_visible(false);
+font_family_group.set_visible(false);
+number_options_group.set_visible(false);
+arrow_style_group.set_visible(false);
+stroke_size_group.set_visible(false);
+```
+
+Keep the remaining non-migrated tool groups untouched.
+
+- [ ] **Step 3: Re-run toolbar regression coverage and compile checks**
+
+Run:
+
+```bash
+cargo test toolbar_no_longer_exposes_arrow_text_and_number_detail_groups --lib
+cargo check
+```
+
+Expected: PASS on both commands.
+
+- [ ] **Step 4: Verify no width-specific code was introduced**
+
+Check that the migration reuses the existing sidebar width rather than creating tool-specific widths:
+
+```bash
+rg -n "width_request|set_width_request|BACKGROUND_SIDEBAR_WIDTH" src/capture/editor/window
+```
+
+Expected: the migrated panels reuse the existing inspector width path and do not introduce new per-tool width constants or divergent width requests.
+
+- [ ] **Step 5: Commit the control migration**
+
+```bash
+git add src/capture/editor/window/mod.rs src/capture/editor/window/toolbar.rs src/capture/editor/window/events.rs src/capture/editor/window/tool_panels.rs
+git commit -m "feat: move arrow text and number controls into the right inspector"
+```
+
+### Task 5: Final verification for inspector behavior and shared colors sync
+
+**Files:**
+- Modify: none unless verification exposes a bug
+
+- [ ] **Step 1: Run the focused automated verification**
+
+Run:
+
+```bash
+cargo test arrow_text_and_number_route_to_tool_specific_inspector_tabs toolbar_no_longer_exposes_arrow_text_and_number_detail_groups --lib
+cargo check
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run manual editor verification**
+
+Open the annotate editor and verify:
+
+```text
+1. Select Arrow and confirm the inspector shows "Arrow | Colors" and opens on Arrow.
+2. Select Text and confirm the inspector shows "Text | Colors" and opens on Text.
+3. Select Number and confirm the inspector shows "Number | Colors" and opens on Number.
+4. Switch each of those tools to Colors and confirm shared color changes still affect the active tool.
+5. Confirm the main toolbar no longer shows Arrow style, Text size/font, or Number options.
+6. Re-check Background to confirm "Background | Colors" still behaves as before.
+7. Confirm the inspector width is unchanged when switching between Background, Arrow, Text, and Number.
+```
+
+- [ ] **Step 3: Commit the verified slice**
+
+```bash
+git add -A
+git commit -m "feat: finish right inspector migration for arrow text and number"
+```
+
+## Self-review
+
+Spec coverage:
+- tool-specific primary tabs for `Arrow`, `Text`, and `Number` are covered by Tasks 2 and 3
+- shared `Colors` tab preservation is covered by Tasks 3 and 5
+- toolbar decluttering is covered by Tasks 1 and 4
+- regression checks for unchanged Background behavior are covered by Task 5
+
+Placeholder scan:
+- no `TODO` or `TBD` placeholders remain
+- every task names exact files and commands
+
+Type consistency:
+- the plan uses one new module name, `tool_panels.rs`, consistently
+- inspector surfaces are consistently named `"arrow"`, `"text"`, `"number"`, `"background"`, and `"colors"`

--- a/docs/superpowers/specs/2026-04-07-right-inspector-arrow-panel-sections-design.md
+++ b/docs/superpowers/specs/2026-04-07-right-inspector-arrow-panel-sections-design.md
@@ -1,0 +1,67 @@
+# Right Inspector Arrow Panel Sections Design
+
+## Goal
+Expand the Arrow tool's right-inspector primary tab into a fuller panel with three sections: `Style`, `Thickness`, and `Behavior`. This should make the Arrow panel feel complete without changing the inspector width and without turning this migration slice into a broader net-new arrow feature project.
+
+## Scope
+This change covers the Arrow tool's primary right-inspector tab only.
+
+Included:
+- keep the existing `Arrow | Colors` inspector tab structure
+- add a `Style` section for the existing arrow variants
+- add a `Thickness` section for the existing stroke thickness choices already supported by the editor
+- add a `Behavior` section only for controls that already map to existing live Arrow state or config
+- keep the Arrow panel on the same fixed inspector width used today
+
+Not included:
+- redesigning the shared `Colors` tab
+- changing Text, Number, or other tool panels in this change
+- introducing brand-new Arrow rendering behavior that needs new editor state or render math
+- changing the overall inspector shell width or layout model
+
+## Arrow Panel Structure
+The Arrow primary tab should be organized as three stacked sections:
+
+### Style
+This section shows the existing Arrow style variants already supported by `ArrowStyle`. It should use direct sidebar-native controls rather than toolbar-style dropdown triggers.
+
+### Thickness
+This section shows the existing stroke size options used by Arrow today. Because stroke size is already part of current editor behavior, this section should simply surface the same choices in the Arrow panel.
+
+### Behavior
+This section should contain Arrow-only behavior controls only when they already map to existing live state or config. The first candidate is surfacing the existing inverse-arrow-direction behavior if it can be cleanly wired as a live Arrow control.
+
+## Behavior Rules
+- `Behavior` is Arrow-only in this slice
+- each control in `Behavior` must already have a real state or config hook in the current codebase
+- if a candidate control needs new render logic, new data model fields, or new interaction semantics, it is out of scope for this implementation and should be deferred to a separate design
+
+## Architecture
+The Arrow panel should be built as inspector-native UI, not as reused toolbar dropdown shells.
+
+Core structure:
+- the right inspector shell in `src/capture/editor/window/mod.rs` continues to own tab routing
+- the Arrow primary surface renders three direct sections: `Style`, `Thickness`, and `Behavior`
+- section controls call the same editor-state update hooks already used by current Arrow controls wherever those hooks already exist
+- the inspector width continues to use the existing fixed sidebar width path
+
+## Candidate Behavior Control
+Recommended first `Behavior` control:
+- inverse arrow direction, if it can be mapped to the existing `inverse_arrow_direction` path as a live Arrow toggle
+
+Deferred examples:
+- angle snapping
+- per-arrow head size
+- curve tension
+- new double-arrow placement controls
+
+These are deferred because they would expand scope into new Arrow feature work rather than a clean inspector-panel completion.
+
+## Testing
+Verification should cover:
+- Arrow inspector renders `Style`, `Thickness`, and `Behavior` sections in the primary Arrow tab
+- Arrow style changes still update the active Arrow behavior
+- Arrow thickness changes still update the existing stroke size state used for Arrow
+- any `Behavior` control included in this slice maps to an already-supported live hook
+- the `Colors` tab remains unchanged
+- inspector width remains unchanged

--- a/docs/superpowers/specs/2026-04-07-right-inspector-arrow-text-number-design.md
+++ b/docs/superpowers/specs/2026-04-07-right-inspector-arrow-text-number-design.md
@@ -1,0 +1,68 @@
+# Right Inspector Arrow Text Number Migration Design
+
+## Goal
+Move the `Arrow`, `Text`, and `Number` tool-specific sub-controls out of the annotate editor main toolbar and into the persistent right inspector so the toolbar becomes less crowded without changing the underlying editing behavior. Each migrated tool should follow the same two-tab inspector pattern already established for `Background`: a tool-specific primary tab plus the shared `Colors` tab.
+
+## Scope
+This change covers the annotate editor right inspector and main toolbar only.
+
+Included:
+- route `Arrow`, `Text`, and `Number` to dedicated primary inspector tabs
+- keep `Colors` as the second tab for each of those tools
+- move the existing tool-specific sub-controls for those tools from the main toolbar into the right inspector
+- keep the moved controls wired to the same editor state and callbacks they use today
+- remove the migrated sub-control widgets from the main toolbar
+
+Not included:
+- redesigning the shared `Colors` tab behavior
+- changing on-canvas text editing behavior
+- introducing new tool capabilities or new state models
+- redesigning non-migrated tool panels in this change
+
+## Tool Behavior
+### Arrow
+The inspector shows `Arrow | Colors` when the Arrow tool is active. The default active tab is `Arrow`. The `Arrow` tab contains the arrow-specific controls that currently live in the toolbar, beginning with arrow style or variant selection and any other Arrow-only controls already supported by the current editor wiring.
+
+### Text
+The inspector shows `Text | Colors` when the Text tool is active. The default active tab is `Text`. The `Text` tab contains the text-specific controls that currently live in the toolbar, such as text sizing and any existing text-only appearance settings. Canvas-based text placement and inline editing continue to work as they do now.
+
+### Number
+The inspector shows `Number | Colors` when the Number tool is active. The default active tab is `Number`. The `Number` tab contains the number-tool controls that currently live in the toolbar, including existing badge or marker style controls already supported by the editor.
+
+### Shared Colors Tab
+For all three tools, `Colors` remains the shared inspector surface owned by the existing colors-panel implementation. The tab behavior should match the current `Background | Colors` pattern so the right inspector feels consistent across color-capable tools.
+
+### Tab Selection Rules
+- selecting `Arrow`, `Text`, or `Number` opens that tool's primary tab by default
+- if the user manually switches to `Colors`, the inspector may keep that tab active until normal routing rules intentionally reset it
+- switching between these tools should preserve the inspector shell and swap only the primary tab label and content
+
+## Architecture
+The migration should reuse the existing right-inspector shell and editor-state wiring rather than introducing inspector-only state.
+
+Core structure:
+- `src/capture/editor/window/mod.rs` owns inspector routing and decides which primary tool panel is mounted beside `Colors`
+- `src/capture/editor/window/colors_panel.rs` continues to own the shared color-management surface
+- `src/capture/editor/window/toolbar.rs` stops rendering the migrated `Arrow`, `Text`, and `Number` sub-tool controls
+- tool-specific inspector panel builders own the moved UI for `Arrow`, `Text`, and `Number`
+
+The inspector panels should call the same update hooks and mutate the same editor state that the toolbar controls use today. This keeps behavior stable while changing only where the controls render.
+
+## Toolbar Responsibilities After Migration
+The main toolbar should focus on high-level controls such as tool selection and any remaining global actions or compact status affordances. It should no longer be the place where `Arrow`, `Text`, and `Number` expose their detailed sub-tool settings.
+
+## File Impact
+- `src/capture/editor/window/mod.rs`
+- `src/capture/editor/window/toolbar.rs`
+- `src/capture/editor/window/colors_panel.rs`
+- new or updated tool-specific inspector panel module(s) for `Arrow`, `Text`, and `Number`
+- `src/capture/editor/ui_support.rs` if sidebar-specific styling is needed for the migrated controls
+
+## Testing
+Verification should cover both routing and regression behavior:
+- the inspector shows `Arrow | Colors`, `Text | Colors`, and `Number | Colors` for the migrated tools
+- selecting each tool defaults to its primary tab
+- the moved controls still update the same editor state as before
+- the main toolbar no longer renders the migrated sub-tool controls
+- the shared `Colors` tab remains synchronized with the active tool color state
+- `Background` inspector behavior remains unchanged

--- a/src/capture/editor/state.rs
+++ b/src/capture/editor/state.rs
@@ -342,7 +342,7 @@ impl EditorState {
             crop_background_color_explicit: false,
             actions: Vec::new(),
             redo_actions: Vec::new(),
-            selected_tool: Tool::Arrow,
+            selected_tool: Tool::Background,
             selected_action_index: None,
             selected_color: DRAW_COLORS[DEFAULT_COLOR_INDEX],
             stroke_size: STROKE_WIDTH,
@@ -2209,6 +2209,19 @@ impl EditorState {
         self.active_text_is_dragging = false;
         self.active_text_drag_handle = None;
         self.active_text_drag_start = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn editor_state_defaults_to_background_tool() {
+        let source = include_str!("state.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("selected_tool: Tool::Background,"),
+            "Editor state should default to the Background tool so startup inspector width matches the initial tool surface",
+        );
     }
 }
 

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1147,10 +1147,12 @@ pub fn install_editor_css() {
             }
 
             .editor-right-inspector {
-                min-width: 280px;
+                min-width: 210px;
+                width: 210px;
+                max-width: 210px;
                 background: rgba(20, 20, 20, 0.94);
                 border-left: 1px solid rgba(255,255,255,0.08);
-                padding: 16px;
+                padding: 0;
             }
 
             .editor-inspector-title {
@@ -1160,7 +1162,10 @@ pub fn install_editor_css() {
             }
 
             .editor-inspector-tabs {
+                margin-top: 16px;
                 margin-bottom: 12px;
+                margin-left: 16px;
+                margin-right: 16px;
             }
 
             button.editor-inspector-tab-button {
@@ -1185,7 +1190,8 @@ pub fn install_editor_css() {
             }
 
             .editor-inspector-placeholder-shell {
-                padding: 2px 0;
+                min-width: 210px;
+                padding: 16px;
             }
 
             .editor-inspector-placeholder {
@@ -1197,7 +1203,7 @@ pub fn install_editor_css() {
 
             .editor-background-sidebar {
                 min-width: 210px;
-                padding: 0;
+                padding: 16px;
                 background: transparent;
                 border-right: none;
             }
@@ -1220,7 +1226,7 @@ pub fn install_editor_css() {
 
             .editor-colors-panel {
                 min-width: 210px;
-                padding: 2px 0;
+                padding: 16px;
             }
 
             .editor-colors-panel-helper {
@@ -1433,10 +1439,10 @@ pub fn install_editor_css() {
             }
 
             .editor-background-alignment-icon-frame {
-                min-width: 20px;
-                min-height: 20px;
+                min-width: 10px;
+                min-height: 6px;
                 background: rgba(241, 241, 243, 0.88);
-                border-radius: 2px;
+                border-radius: 1px;
                 margin: 3px;
                 border: none;
             }
@@ -2187,8 +2193,14 @@ mod tests {
         assert!(
             production_source.contains("button.editor-inspector-tab-button {\n                min-height: 20px;\n                padding: 0;\n                border-radius: 0;\n                border: none;\n                background: transparent;")
                 && production_source.contains("button.editor-inspector-tab-button.active-inspector-tab {\n                background: transparent;\n                border: none;\n                color: #ff9900;")
-                && production_source.contains(".editor-colors-panel {\n                min-width: 210px;"),
-            "inspector tabs should be text-only with orange active text and colors panel should match background width",
+                && production_source.contains(".editor-inspector-tabs {\n                margin-top: 16px;\n                margin-bottom: 12px;")
+                && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
+                && production_source.contains(".editor-inspector-placeholder-shell {\n                min-width: 210px;")
+                && production_source.contains(".editor-background-sidebar {\n                min-width: 210px;")
+                && production_source.contains(".editor-colors-panel {\n                min-width: 210px;")
+                && !production_source.contains(".editor-background-sidebar {\n                min-width: 210px;\n                width: 210px;")
+                && !production_source.contains(".editor-colors-panel {\n                min-width: 210px;\n                width: 210px;"),
+            "inspector tabs should be text-only, with a fixed shell width but flexible inner panel surfaces",
         );
     }
 

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1201,6 +1201,29 @@ pub fn install_editor_css() {
                 line-height: 1.45;
             }
 
+            .editor-inspector-section {
+                margin-bottom: 12px;
+            }
+
+            .editor-inspector-section-body {
+                background: #000000;
+                border: 1px solid rgba(255, 255, 255, 0.11);
+                border-radius: 6px;
+                overflow: hidden;
+            }
+
+            .editor-inspector-option-list {
+                background: transparent;
+            }
+
+            .editor-inspector-toggle-row {
+                padding: 10px 12px;
+            }
+
+            .editor-inspector-toggle-row checkbutton {
+                color: rgba(241, 241, 243, 0.9);
+            }
+
             .editor-background-sidebar {
                 min-width: 210px;
                 padding: 16px;

--- a/src/capture/editor/window/colors_panel.rs
+++ b/src/capture/editor/window/colors_panel.rs
@@ -50,18 +50,19 @@ pub fn build_colors_panel(
     let root = GtkBox::new(Orientation::Vertical, 12);
     root.add_css_class("editor-colors-panel");
     root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
-    root.set_hexpand(true);
+    root.set_hexpand(false);
     root.set_halign(gtk4::Align::Fill);
     root.set_vexpand(true);
 
     let content = GtkBox::new(Orientation::Vertical, 12);
-    content.set_hexpand(true);
+    content.set_hexpand(false);
     content.set_halign(gtk4::Align::Fill);
 
     let helper = Label::new(Some("Choose a color for the active tool"));
     helper.add_css_class("editor-colors-panel-helper");
     helper.set_wrap(true);
     helper.set_max_width_chars(26);
+    helper.set_halign(gtk4::Align::Fill);
     helper.set_xalign(0.0);
 
     let picker_state = Rc::new(RefCell::new(PickerColorState::from_color(DRAW_COLORS[0])));
@@ -85,7 +86,7 @@ pub fn build_colors_panel(
     gradient_area.set_content_height(140);
     gradient_area.set_size_request(BACKGROUND_SIDEBAR_WIDTH, 140);
     gradient_area.set_halign(gtk4::Align::Fill);
-    gradient_area.set_hexpand(true);
+    gradient_area.set_hexpand(false);
     gradient_area.add_css_class("editor-gradient-area");
     let picker_state_draw = picker_state.clone();
     gradient_area.set_draw_func(move |_area, cr: &gtk4::cairo::Context, width, height| {
@@ -852,9 +853,9 @@ mod tests {
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
             production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
-                && production_source.contains("root.set_hexpand(true);")
+                && production_source.contains("root.set_hexpand(false);")
                 && production_source.contains("root.set_halign(gtk4::Align::Fill);")
-                && production_source.contains("content.set_hexpand(true);")
+                && production_source.contains("content.set_hexpand(false);")
                 && production_source.contains("content.set_halign(gtk4::Align::Fill);")
                 && production_source.contains("palette_section.set_hexpand(true);")
                 && production_source.contains("palette_section.set_halign(gtk4::Align::Fill);")
@@ -874,6 +875,9 @@ mod tests {
                 && production_source.contains("actions.set_hexpand(true);")
                 && production_source.contains("add_current_color_btn.set_hexpand(true);")
                 && production_source.contains("pick_from_screen_btn.set_hexpand(true);")
+                && production_source.contains("helper.set_halign(gtk4::Align::Fill);")
+                && !production_source.contains("helper.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("content.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
                 && !production_source.contains("palette_grid.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
                 && !production_source.contains("custom_grid.set_width_request(BACKGROUND_SIDEBAR_WIDTH);"),
             "Colors panel should use the same content width as the Background panel",

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -1,7 +1,7 @@
 use gtk4::{
     gdk, glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, DrawingArea,
-    EventControllerKey, EventControllerMotion, GestureClick, GestureDrag, Image, Label, Popover,
-    Scale,
+    EventControllerKey, EventControllerMotion, GestureClick, GestureDrag, Image, Label,
+    Popover, Scale, CheckButton,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
@@ -112,6 +112,8 @@ pub(super) struct EventContext {
     pub number_size_list: gtk4::Box,
     pub arrow_style_button: Button,
     pub arrow_style_list: gtk4::Box,
+    pub arrow_thickness_list: gtk4::Box,
+    pub inverse_direction_toggle: CheckButton,
     pub stroke_size_button: Button,
     pub stroke_size_list: gtk4::Box,
 }
@@ -187,6 +189,8 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         number_size_list,
         arrow_style_button,
         arrow_style_list,
+        arrow_thickness_list,
+        inverse_direction_toggle,
         stroke_size_button,
         stroke_size_list,
     } = ctx;
@@ -897,6 +901,62 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
             }
         });
     }
+
+    let arrow_thickness_sizes: [(f64, PenWeight); 4] = [
+        (2.0, PenWeight::Small),
+        (4.0, PenWeight::Medium),
+        (7.0, PenWeight::Large),
+        (12.0, PenWeight::ExtraLarge),
+    ];
+
+    let mut thickness_idx = 0usize;
+    let mut child_opt = arrow_thickness_list.first_child();
+    while let Some(child) = child_opt {
+        child_opt = child.next_sibling();
+
+        let Ok(button) = child.clone().downcast::<Button>() else {
+            continue;
+        };
+
+        let Some(&(size, weight)) = arrow_thickness_sizes.get(thickness_idx) else {
+            break;
+        };
+        thickness_idx += 1;
+
+        let state_stroke = state.clone();
+        let drawing_area_stroke = drawing_area.downgrade();
+        let stroke_size_button_clone = stroke_size_button.clone();
+
+        button.connect_clicked(move |_| {
+            {
+                let mut st = state_stroke.lock().unwrap();
+                st.set_stroke_size(size);
+            }
+
+            let icon = gtk4::Image::from_icon_name(weight.icon_name());
+            icon.set_pixel_size(weight.icon_pixel_size());
+            stroke_size_button_clone.set_child(Some(&icon));
+
+            if let Some(area) = drawing_area_stroke.upgrade() {
+                area.queue_draw();
+            }
+        });
+    }
+
+    inverse_direction_toggle.connect_toggled({
+        let state = state.clone();
+        let drawing_area = drawing_area.downgrade();
+        move |toggle| {
+            {
+                let mut st = state.lock().unwrap();
+                st.inverse_arrow_direction = toggle.is_active();
+            }
+
+            if let Some(area) = drawing_area.upgrade() {
+                area.queue_draw();
+            }
+        }
+    });
 
     let refresh_number_start_display: Rc<dyn Fn()> = Rc::new({
         let state = state.clone();

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -2,7 +2,7 @@ use gdk4x11::X11Surface;
 use gtk4::gdk;
 use gtk4::{
     glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation,
-    Popover,
+    Popover, Stack,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
@@ -12,6 +12,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{SystemTime, UNIX_EPOCH};
 use x11rb::{connection::Connection, protocol::xproto, protocol::xproto::ConnectionExt};
 
+use self::background_panel::BACKGROUND_SIDEBAR_WIDTH;
 use super::color::{draw_color_to_hex, draw_color_to_rgba_u8, selection_hit_padding_for_scale};
 use super::render::{
     draw_active_text_input, draw_annotation_action, draw_arrow_control_handles,
@@ -745,6 +746,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let placeholder_inspector = GtkBox::new(Orientation::Vertical, 12);
     placeholder_inspector.add_css_class("editor-inspector-placeholder-shell");
+    placeholder_inspector.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
+    placeholder_inspector.set_hexpand(false);
     placeholder_inspector.set_vexpand(true);
 
     let placeholder_title = Label::new(Some("Inspector"));
@@ -761,6 +764,9 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let inspector_tabs = GtkBox::new(Orientation::Horizontal, 8);
     inspector_tabs.add_css_class("editor-inspector-tabs");
+    inspector_tabs.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
+    inspector_tabs.set_hexpand(false);
+    inspector_tabs.set_halign(gtk4::Align::Fill);
 
     let background_tab_btn = Button::with_label("Background");
     background_tab_btn.set_has_frame(false);
@@ -775,13 +781,25 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let inspector = GtkBox::new(Orientation::Vertical, 0);
     inspector.add_css_class("editor-right-inspector");
-    inspector.set_width_request(280);
+    inspector.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
     inspector.set_hexpand(false);
     inspector.set_vexpand(true);
     inspector.append(&inspector_tabs);
-    inspector.append(&background_inspector);
-    inspector.append(&colors_inspector);
-    inspector.append(&placeholder_inspector);
+
+    let inspector_stack = Stack::new();
+    inspector_stack.set_hhomogeneous(true);
+    inspector_stack.set_vhomogeneous(false);
+    inspector_stack.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
+    inspector_stack.set_hexpand(false);
+    inspector_stack.set_vexpand(true);
+    background_inspector.set_visible(true);
+    colors_inspector.set_visible(true);
+    placeholder_inspector.set_visible(true);
+    inspector_stack.add_named(&background_inspector, Some("background"));
+    inspector_stack.add_named(&colors_inspector, Some("colors"));
+    inspector_stack.add_named(&placeholder_inspector, Some("placeholder"));
+    inspector_stack.set_visible_child_name("placeholder");
+    inspector.append(&inspector_stack);
 
     let workspace = GtkBox::new(Orientation::Horizontal, 0);
     workspace.set_hexpand(true);
@@ -793,9 +811,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let update_toolbar_for_tool = toolbar::build_toolbar_tool_updater(
         &toolbar_mode_stack,
-        &background_inspector,
-        &colors_inspector,
-        &placeholder_inspector,
+        &inspector_stack,
         &inspector_tabs,
         &background_tab_btn,
         &colors_tab_btn,
@@ -811,18 +827,13 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     );
 
     let set_active_inspector_surface: Rc<dyn Fn(&str)> = Rc::new({
-        let background_inspector = background_inspector.clone();
-        let colors_inspector = colors_inspector.clone();
-        let placeholder_inspector = placeholder_inspector.clone();
+        let inspector_stack = inspector_stack.clone();
         let background_tab_btn = background_tab_btn.clone();
         let colors_tab_btn = colors_tab_btn.clone();
         move |surface| {
             let show_background = surface == "background";
             let show_colors = surface == "colors";
-            let show_placeholder = surface == "placeholder";
-            background_inspector.set_visible(show_background);
-            colors_inspector.set_visible(show_colors);
-            placeholder_inspector.set_visible(show_placeholder);
+            inspector_stack.set_visible_child_name(surface);
             if show_background {
                 background_tab_btn.add_css_class("active-inspector-tab");
             } else {
@@ -1286,7 +1297,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         }
     });
     sync_size_control();
-    update_toolbar_for_tool(Tool::Arrow);
+    let initial_tool = state.lock().unwrap().selected_tool;
+    update_toolbar_for_tool(initial_tool);
 
     let state_draw = state.clone();
     let transform_draw = transform.clone();
@@ -2156,5 +2168,35 @@ mod tests {
         let source = include_str!("mod.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(production_source.contains("background_inspector"));
+    }
+
+    #[test]
+    fn editor_layout_uses_stack_for_inspector_surface_switching() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let inspector_stack = Stack::new();")
+                && production_source.contains("inspector_stack.set_hhomogeneous(true);")
+                && production_source.contains("background_inspector.set_visible(true);")
+                && production_source.contains("colors_inspector.set_visible(true);")
+                && production_source.contains("placeholder_inspector.set_visible(true);")
+                && production_source.contains("inspector_stack.add_named(&background_inspector, Some(\"background\"));")
+                && production_source.contains("inspector_stack.add_named(&colors_inspector, Some(\"colors\"));")
+                && production_source.contains("inspector_stack.add_named(&placeholder_inspector, Some(\"placeholder\"));")
+                && production_source.contains("inspector_stack.set_visible_child_name(surface);"),
+            "Inspector surfaces should switch through a dedicated stack so tab changes keep one stable container",
+        );
+    }
+
+    #[test]
+    fn editor_startup_uses_selected_tool_instead_of_hardcoded_arrow() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let initial_tool = state.lock().unwrap().selected_tool;")
+                && production_source.contains("update_toolbar_for_tool(initial_tool);")
+                && !production_source.contains("update_toolbar_for_tool(Tool::Arrow);"),
+            "Editor startup should route the inspector from the selected startup tool instead of forcing Arrow",
+        );
     }
 }

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -1,8 +1,8 @@
 use gdk4x11::X11Surface;
 use gtk4::gdk;
 use gtk4::{
-    glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, Label, Orientation,
-    Popover, Stack,
+    glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton, Entry,
+    Image, Label, Orientation, Popover, Stack,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
@@ -24,7 +24,7 @@ use super::render::{
 use super::selection::{action_bounds_with_padding, action_resize_handles};
 use super::state::{apply_effect_actions, EditorState};
 use super::types::{
-    AnnotationAction, BackgroundAlignment, BackgroundStyle, CropAspectRatio, DrawColor,
+    AnnotationAction, ArrowStyle, BackgroundAlignment, BackgroundStyle, CropAspectRatio, DrawColor,
     EditorError, Point, Rect, Tool, ViewTransform,
 };
 
@@ -53,8 +53,9 @@ impl AnnotateRuntimeConfig {
     }
 }
 use super::ui_support::{
-    install_editor_css, prefers_dark_glass_theme, prefers_reduced_transparency,
-    recommended_window_size_with_extra_width,
+    arrow_style_toolbar_icon, install_editor_css, prefers_dark_glass_theme,
+    prefers_reduced_transparency, recommended_window_size_with_extra_width, tool_icon_widget,
+    toolbar_icon_size,
 };
 
 pub mod background_panel;
@@ -354,10 +355,10 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         size_slider,
         text_size_group,
         text_size_label,
-        text_size_list,
+        text_size_list: _toolbar_text_size_list,
         font_family_group,
         font_family_label,
-        font_family_list,
+        font_family_list: _toolbar_font_family_list,
         crop_type_label,
         crop_type_popover,
         crop_type_list,
@@ -372,18 +373,18 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         pen_weight_list,
         pen_weight_group,
         number_options_popover: _,
-        number_options_list,
-        number_start_entry,
-        number_inc_btn,
-        number_dec_btn,
+        number_options_list: _toolbar_number_options_list,
+        number_start_entry: _toolbar_number_start_entry,
+        number_inc_btn: _toolbar_number_inc_btn,
+        number_dec_btn: _toolbar_number_dec_btn,
         number_size_button,
         number_size_popover: _,
-        number_size_list,
+        number_size_list: _toolbar_number_size_list,
         number_options_group,
         arrow_style_group,
         arrow_style_button,
         arrow_style_popover: _,
-        arrow_style_list,
+        arrow_style_list: _toolbar_arrow_style_list,
         stroke_size_group,
         stroke_size_button,
         stroke_size_popover: _,
@@ -420,6 +421,124 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let save_btn = toolbar_right_parts.save_btn;
     let apply_crop_btn = toolbar_right_parts.apply_crop_btn;
     toolbar.set_end_widget(Some(&toolbar_right_parts.root));
+
+    let arrow_style_list = GtkBox::new(Orientation::Vertical, 0);
+    for style in ArrowStyle::ALL {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let style_icon = arrow_style_toolbar_icon(style);
+        let icon = tool_icon_widget(
+            style_icon.clone(),
+            toolbar_icon_size(&style_icon),
+        );
+        let label_widget = Label::new(Some(style.display_name()));
+
+        btn_box.append(&icon);
+        btn_box.append(&label_widget);
+
+        let btn = Button::builder()
+            .has_frame(false)
+            .css_classes(["editor-popover-list-item", "flat"])
+            .child(&btn_box)
+            .build();
+
+        arrow_style_list.append(&btn);
+    }
+
+    let arrow_thickness_list = GtkBox::new(Orientation::Vertical, 0);
+    for (label, _size, weight) in [
+        ("Thin", 2.0_f64, super::pen_weight::PenWeight::Small),
+        ("Medium", 4.0_f64, super::pen_weight::PenWeight::Medium),
+        ("Thick", 7.0_f64, super::pen_weight::PenWeight::Large),
+        ("Very Thick", 12.0_f64, super::pen_weight::PenWeight::ExtraLarge),
+    ] {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let icon = Image::from_icon_name(weight.icon_name());
+        icon.set_pixel_size(weight.icon_pixel_size());
+        let label_widget = Label::new(Some(label));
+
+        btn_box.append(&icon);
+        btn_box.append(&label_widget);
+
+        let btn = Button::builder()
+            .has_frame(false)
+            .css_classes(["editor-popover-list-item", "flat"])
+            .child(&btn_box)
+            .build();
+
+        arrow_thickness_list.append(&btn);
+    }
+
+    let arrow_behavior_group = GtkBox::new(Orientation::Vertical, 0);
+    arrow_behavior_group.add_css_class("editor-inspector-toggle-row");
+    let inverse_direction_toggle = CheckButton::with_label("Reverse direction");
+    arrow_behavior_group.append(&inverse_direction_toggle);
+
+    let text_size_list = GtkBox::new(Orientation::Vertical, 0);
+    let font_family_list = GtkBox::new(Orientation::Vertical, 0);
+
+    let number_options_list = GtkBox::new(Orientation::Vertical, 4);
+    number_options_list.set_margin_start(4);
+    number_options_list.set_margin_end(4);
+    number_options_list.set_margin_top(4);
+    number_options_list.set_margin_bottom(4);
+    for style in super::numbering_style::NumberingStyle::ALL {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        let check_icon = Image::from_icon_name(icon_names::SELECT);
+        check_icon.set_pixel_size(12);
+        check_icon.set_visible(style == super::numbering_style::NumberingStyle::default());
+        check_icon.add_css_class("editor-number-style-check");
+
+        let label = Label::new(Some(style.label()));
+        label.set_hexpand(true);
+        label.set_halign(gtk4::Align::Start);
+
+        btn_box.append(&check_icon);
+        btn_box.append(&label);
+
+        let btn = Button::builder()
+            .has_frame(false)
+            .css_classes([
+                "editor-popover-list-item",
+                "flat",
+                "editor-number-style-option",
+            ])
+            .child(&btn_box)
+            .build();
+        number_options_list.append(&btn);
+    }
+
+    let number_start_entry = Entry::new();
+    number_start_entry.set_width_chars(5);
+    number_start_entry.set_max_width_chars(5);
+    number_start_entry.set_text("1");
+    number_start_entry.set_editable(false);
+    number_start_entry.add_css_class("editor-number-start-entry");
+    let number_inc_btn = Button::with_label("+");
+    let number_dec_btn = Button::with_label("-");
+
+    let number_size_list = GtkBox::new(Orientation::Vertical, 0);
+    for size in super::numbering_style::NumberSize::ALL {
+        let btn = Button::builder()
+            .label(size.label())
+            .has_frame(false)
+            .css_classes([
+                "editor-popover-list-item",
+                "flat",
+                "editor-number-size-option",
+            ])
+            .build();
+        number_size_list.append(&btn);
+    }
 
     let footer_parts = footer::build_footer(
         icon_names::VIEW_PIN,
@@ -762,6 +881,105 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     placeholder_inspector.append(&placeholder_title);
     placeholder_inspector.append(&placeholder);
 
+    if let Some(parent) = text_size_list.parent() {
+        if let Ok(popover) = parent.downcast::<Popover>() {
+            popover.set_child(Option::<&gtk4::Widget>::None);
+        }
+    }
+    if let Some(parent) = font_family_list.parent() {
+        if let Ok(popover) = parent.downcast::<Popover>() {
+            popover.set_child(Option::<&gtk4::Widget>::None);
+        }
+    }
+    if let Some(parent) = arrow_style_list.parent() {
+        if let Ok(popover) = parent.downcast::<Popover>() {
+            popover.set_child(Option::<&gtk4::Widget>::None);
+        }
+    }
+    if let Some(parent) = number_options_list.parent() {
+        if let Ok(popover) = parent.downcast::<Popover>() {
+            popover.set_child(Option::<&gtk4::Widget>::None);
+        }
+    }
+    if let Some(parent) = number_size_list.parent() {
+        if let Ok(popover) = parent.downcast::<Popover>() {
+            popover.set_child(Option::<&gtk4::Widget>::None);
+        }
+    }
+    if let Some(parent) = number_size_button.parent() {
+        if let Ok(container) = parent.downcast::<GtkBox>() {
+            container.remove(&number_size_button);
+        }
+    }
+
+    text_size_group.set_visible(false);
+    font_family_group.set_visible(false);
+    number_options_group.set_visible(false);
+    arrow_style_group.set_visible(false);
+
+    let build_tool_inspector = || {
+        let root = GtkBox::new(Orientation::Vertical, 12);
+        root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
+        root.set_hexpand(false);
+        root.set_halign(gtk4::Align::Fill);
+        root.set_vexpand(true);
+
+        let content = GtkBox::new(Orientation::Vertical, 10);
+        content.set_margin_top(4);
+        content.set_margin_bottom(12);
+        content.set_margin_start(12);
+        content.set_margin_end(12);
+        content.set_hexpand(false);
+        content.set_halign(gtk4::Align::Fill);
+
+        root.append(&content);
+        (root, content)
+    };
+
+    let append_inspector_section = |content: &GtkBox, title: &str, widget: &gtk4::Widget| {
+            let section = GtkBox::new(Orientation::Vertical, 8);
+            section.add_css_class("editor-inspector-section");
+
+            let section_title = Label::new(Some(title));
+            section_title.add_css_class("editor-background-section-title");
+            section_title.set_xalign(0.0);
+
+            let section_body = GtkBox::new(Orientation::Vertical, 0);
+            section_body.add_css_class("editor-inspector-section-body");
+            section_body.append(widget);
+
+            section.append(&section_title);
+            section.append(&section_body);
+            content.append(&section);
+        };
+
+    let (arrow_inspector, arrow_inspector_content) = build_tool_inspector();
+    arrow_style_list.add_css_class("editor-inspector-option-list");
+    arrow_thickness_list.add_css_class("editor-inspector-option-list");
+    append_inspector_section(&arrow_inspector_content, "Style", arrow_style_list.upcast_ref());
+    append_inspector_section(
+        &arrow_inspector_content,
+        "Thickness",
+        arrow_thickness_list.upcast_ref(),
+    );
+    append_inspector_section(
+        &arrow_inspector_content,
+        "Behavior",
+        arrow_behavior_group.upcast_ref(),
+    );
+
+    let (text_inspector, text_inspector_content) = build_tool_inspector();
+    text_size_list.add_css_class("editor-inspector-option-list");
+    font_family_list.add_css_class("editor-inspector-option-list");
+    append_inspector_section(&text_inspector_content, "Size", text_size_list.upcast_ref());
+    append_inspector_section(&text_inspector_content, "Font", font_family_list.upcast_ref());
+
+    let (number_inspector, number_inspector_content) = build_tool_inspector();
+    number_options_list.add_css_class("editor-inspector-option-list");
+    number_size_list.add_css_class("editor-inspector-option-list");
+    append_inspector_section(&number_inspector_content, "Style", number_options_list.upcast_ref());
+    append_inspector_section(&number_inspector_content, "Size", number_size_list.upcast_ref());
+
     let inspector_tabs = GtkBox::new(Orientation::Horizontal, 8);
     inspector_tabs.add_css_class("editor-inspector-tabs");
     inspector_tabs.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
@@ -793,9 +1011,15 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     inspector_stack.set_hexpand(false);
     inspector_stack.set_vexpand(true);
     background_inspector.set_visible(true);
+    arrow_inspector.set_visible(true);
+    text_inspector.set_visible(true);
+    number_inspector.set_visible(true);
     colors_inspector.set_visible(true);
     placeholder_inspector.set_visible(true);
     inspector_stack.add_named(&background_inspector, Some("background"));
+    inspector_stack.add_named(&arrow_inspector, Some("arrow"));
+    inspector_stack.add_named(&text_inspector, Some("text"));
+    inspector_stack.add_named(&number_inspector, Some("number"));
     inspector_stack.add_named(&colors_inspector, Some("colors"));
     inspector_stack.add_named(&placeholder_inspector, Some("placeholder"));
     inspector_stack.set_visible_child_name("placeholder");
@@ -809,7 +1033,16 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     *drawing_area_placeholder.borrow_mut() = Some(drawing_area.downgrade());
 
-    let update_toolbar_for_tool = toolbar::build_toolbar_tool_updater(
+    let sync_arrow_behavior_controls: Rc<dyn Fn()> = Rc::new({
+        let state = state.clone();
+        let inverse_direction_toggle = inverse_direction_toggle.clone();
+        move || {
+            let st = state.lock().unwrap();
+            inverse_direction_toggle.set_active(st.inverse_arrow_direction);
+        }
+    });
+
+    let update_toolbar_for_tool_base = toolbar::build_toolbar_tool_updater(
         &toolbar_mode_stack,
         &inspector_stack,
         &inspector_tabs,
@@ -825,13 +1058,23 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &canvas_scroller,
         start_background_gradient_preview_loading.clone(),
     );
+    let update_toolbar_for_tool: Rc<dyn Fn(Tool)> = Rc::new({
+        let update_toolbar_for_tool_base = update_toolbar_for_tool_base.clone();
+        let sync_arrow_behavior_controls = sync_arrow_behavior_controls.clone();
+        move |tool| {
+            update_toolbar_for_tool_base(tool);
+            if matches!(tool, Tool::Arrow) {
+                sync_arrow_behavior_controls();
+            }
+        }
+    });
 
     let set_active_inspector_surface: Rc<dyn Fn(&str)> = Rc::new({
         let inspector_stack = inspector_stack.clone();
         let background_tab_btn = background_tab_btn.clone();
         let colors_tab_btn = colors_tab_btn.clone();
         move |surface| {
-            let show_background = surface == "background";
+            let show_background = matches!(surface, "background" | "arrow" | "text" | "number");
             let show_colors = surface == "colors";
             inspector_stack.set_visible_child_name(surface);
             if show_background {
@@ -851,8 +1094,15 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         let state = state.clone();
         let set_active_inspector_surface = set_active_inspector_surface.clone();
         move |_| {
-            if state.lock().unwrap().selected_tool == Tool::Background {
-                set_active_inspector_surface("background");
+            let surface = match state.lock().unwrap().selected_tool {
+                Tool::Background => Some("background"),
+                Tool::Arrow => Some("arrow"),
+                Tool::Text => Some("text"),
+                Tool::Number => Some("number"),
+                _ => None,
+            };
+            if let Some(surface) = surface {
+                set_active_inspector_surface(surface);
             }
         }
     });
@@ -2105,6 +2355,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         number_size_list: number_size_list.clone(),
         arrow_style_button: arrow_style_button.clone(),
         arrow_style_list: arrow_style_list.clone(),
+        arrow_thickness_list: arrow_thickness_list.clone(),
+        inverse_direction_toggle: inverse_direction_toggle.clone(),
         stroke_size_button: stroke_size_button.clone(),
         stroke_size_list: stroke_size_list.clone(),
     });
@@ -2178,9 +2430,15 @@ mod tests {
             production_source.contains("let inspector_stack = Stack::new();")
                 && production_source.contains("inspector_stack.set_hhomogeneous(true);")
                 && production_source.contains("background_inspector.set_visible(true);")
+                && production_source.contains("arrow_inspector.set_visible(true);")
+                && production_source.contains("text_inspector.set_visible(true);")
+                && production_source.contains("number_inspector.set_visible(true);")
                 && production_source.contains("colors_inspector.set_visible(true);")
                 && production_source.contains("placeholder_inspector.set_visible(true);")
                 && production_source.contains("inspector_stack.add_named(&background_inspector, Some(\"background\"));")
+                && production_source.contains("inspector_stack.add_named(&arrow_inspector, Some(\"arrow\"));")
+                && production_source.contains("inspector_stack.add_named(&text_inspector, Some(\"text\"));")
+                && production_source.contains("inspector_stack.add_named(&number_inspector, Some(\"number\"));")
                 && production_source.contains("inspector_stack.add_named(&colors_inspector, Some(\"colors\"));")
                 && production_source.contains("inspector_stack.add_named(&placeholder_inspector, Some(\"placeholder\"));")
                 && production_source.contains("inspector_stack.set_visible_child_name(surface);"),
@@ -2197,6 +2455,46 @@ mod tests {
                 && production_source.contains("update_toolbar_for_tool(initial_tool);")
                 && !production_source.contains("update_toolbar_for_tool(Tool::Arrow);"),
             "Editor startup should route the inspector from the selected startup tool instead of forcing Arrow",
+        );
+    }
+
+    #[test]
+    fn arrow_text_and_number_route_to_tool_specific_inspector_tabs() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("Tool::Arrow")
+                && production_source.contains("Tool::Text")
+                && production_source.contains("Tool::Number")
+                && production_source.contains("\"arrow\"")
+                && production_source.contains("\"text\"")
+                && production_source.contains("\"number\"")
+                && production_source.contains("\"colors\""),
+            "Inspector routing should expose Arrow, Text, and Number primary panels alongside the shared Colors surface",
+        );
+    }
+
+    #[test]
+    fn arrow_inspector_includes_style_thickness_and_behavior_sections() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let (arrow_inspector, arrow_inspector_content) = build_tool_inspector();")
+                && production_source.contains("\"Style\"")
+                && production_source.contains("\"Thickness\"")
+                && production_source.contains("\"Behavior\""),
+            "Arrow inspector should render Style, Thickness, and Behavior sections",
+        );
+    }
+
+    #[test]
+    fn arrow_inspector_reuses_existing_fixed_sidebar_width() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("ARROW_SIDEBAR_WIDTH"),
+            "Arrow inspector should reuse the shared fixed sidebar width instead of introducing a new width path",
         );
     }
 }

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -992,8 +992,6 @@ pub(super) fn build_toolbar_mode_controls(
     standard_mode_group.append(&obfuscate_method_group);
     standard_mode_group.append(&pen_weight_group);
     standard_mode_group.append(&stroke_size_group);
-    standard_mode_group.append(&arrow_style_group);
-    standard_mode_group.append(&number_options_group);
     standard_mode_group.append(&size_group);
 
     let toolbar_mode_stack = Stack::new();
@@ -1009,8 +1007,6 @@ pub(super) fn build_toolbar_mode_controls(
     root.append(&crop_tools_group);
     root.append(&background_tools_group);
     root.append(&toolbar_mode_stack);
-    root.append(&text_size_group);
-    root.append(&font_family_group);
     ToolbarModeParts {
         root,
         toolbar_mode_stack,
@@ -1179,6 +1175,13 @@ pub(super) fn build_toolbar_right_controls(
             canvas_scroller.set_policy(gtk4::PolicyType::Never, gtk4::PolicyType::Never);
         }
 
+        let primary_surface = match tool {
+            Tool::Background => Some(("Background", "background")),
+            Tool::Arrow => Some(("Arrow", "arrow")),
+            Tool::Text => Some(("Text", "text")),
+            Tool::Number => Some(("Number", "number")),
+            _ => None,
+        };
         let background_mode = matches!(tool, Tool::Background);
         let colors_mode = matches!(
             tool,
@@ -1194,14 +1197,14 @@ pub(super) fn build_toolbar_right_controls(
                 | Tool::Obfuscate
                 | Tool::Focus
         );
-        background_tab_btn.set_label("Background");
+        background_tab_btn.set_label(primary_surface.map(|(label, _)| label).unwrap_or("Background"));
         colors_tab_btn.set_label("Colors");
-        inspector_tabs.set_visible(background_mode || colors_mode);
-        background_tab_btn.set_visible(background_mode);
+        inspector_tabs.set_visible(primary_surface.is_some() || colors_mode);
+        background_tab_btn.set_visible(primary_surface.is_some());
         colors_tab_btn.set_visible(colors_mode);
 
-        if background_mode {
-            inspector_stack.set_visible_child_name("background");
+        if let Some((_, surface)) = primary_surface {
+            inspector_stack.set_visible_child_name(surface);
             background_tab_btn.add_css_class("active-inspector-tab");
             colors_tab_btn.remove_css_class("active-inspector-tab");
         } else if colors_mode {
@@ -1254,8 +1257,10 @@ mod tests {
         let source = include_str!("toolbar.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
-            production_source.contains("inspector_stack.set_visible_child_name(\"background\");")
-                && production_source.contains("if background_mode {")
+            production_source.contains("let primary_surface = match tool {")
+                && production_source.contains("Tool::Background => Some((\"Background\", \"background\"))")
+                && production_source.contains("if let Some((_, surface)) = primary_surface {")
+                && production_source.contains("inspector_stack.set_visible_child_name(surface);")
                 && production_source.contains("background_tab_btn.add_css_class(\"active-inspector-tab\");")
                 && production_source.contains("colors_tab_btn.remove_css_class(\"active-inspector-tab\");"),
             "Background mode should open on the Background inspector surface instead of the Colors surface",
@@ -1286,16 +1291,19 @@ mod tests {
     }
 
     #[test]
-    fn non_background_color_tools_default_to_colors_inspector_surface() {
+    fn non_migrated_color_tools_default_to_colors_inspector_surface() {
         let source = include_str!("toolbar.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
             production_source.contains("inspector_stack.set_visible_child_name(\"colors\");")
                 && production_source.contains("} else if colors_mode {")
-                && production_source.contains("Tool::Background")
                 && production_source.contains("Tool::Pen")
-                && production_source.contains("Tool::Focus"),
-            "Non-background color-capable tools should switch the right inspector to the Colors surface",
+                && production_source.contains("Tool::Line")
+                && production_source.contains("Tool::Obfuscate")
+                && !production_source.contains("Tool::Arrow => Some((\"Arrow\", \"colors\"))")
+                && !production_source.contains("Tool::Text => Some((\"Text\", \"colors\"))")
+                && !production_source.contains("Tool::Number => Some((\"Number\", \"colors\"))"),
+            "Non-migrated color-capable tools should still switch the right inspector to the Colors surface",
         );
     }
 
@@ -1309,6 +1317,19 @@ mod tests {
                 && production_source.contains("Tool::Highlighter")
                 && production_source.contains("\"Colors\""),
             "Toolbar inspector routing should include Background and color-capable tools in the shared Colors flow",
+        );
+    }
+
+    #[test]
+    fn toolbar_no_longer_exposes_arrow_text_and_number_detail_groups() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            !production_source.contains("standard_mode_group.append(&arrow_style_group);")
+                && !production_source.contains("standard_mode_group.append(&number_options_group);")
+                && !production_source.contains("root.append(&text_size_group);")
+                && !production_source.contains("root.append(&font_family_group);"),
+            "Toolbar layout should stop mounting Arrow, Text, and Number detail groups after the inspector migration",
         );
     }
 }

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -1117,11 +1117,9 @@ pub(super) fn build_toolbar_right_controls(
     }
 }
 
-pub(super) fn build_toolbar_tool_updater(
+    pub(super) fn build_toolbar_tool_updater(
     toolbar_mode_stack: &Stack,
-    background_inspector: &GtkBox,
-    colors_inspector: &GtkBox,
-    placeholder_inspector: &GtkBox,
+    inspector_stack: &Stack,
     inspector_tabs: &GtkBox,
     background_tab_btn: &Button,
     colors_tab_btn: &Button,
@@ -1136,9 +1134,7 @@ pub(super) fn build_toolbar_tool_updater(
     start_background_gradient_preview_loading: Rc<dyn Fn()>,
 ) -> Rc<dyn Fn(Tool)> {
     let toolbar_mode_stack = toolbar_mode_stack.clone();
-    let background_inspector = background_inspector.clone();
-    let colors_inspector = colors_inspector.clone();
-    let placeholder_inspector = placeholder_inspector.clone();
+    let inspector_stack = inspector_stack.clone();
     let inspector_tabs = inspector_tabs.clone();
     let background_tab_btn = background_tab_btn.clone();
     let colors_tab_btn = colors_tab_btn.clone();
@@ -1204,15 +1200,16 @@ pub(super) fn build_toolbar_tool_updater(
         background_tab_btn.set_visible(background_mode);
         colors_tab_btn.set_visible(colors_mode);
 
-        background_inspector.set_visible(false);
-        colors_inspector.set_visible(colors_mode);
-        placeholder_inspector.set_visible(!background_mode && !colors_mode);
-
-        if background_mode || colors_mode {
-            colors_inspector.set_visible(true);
+        if background_mode {
+            inspector_stack.set_visible_child_name("background");
+            background_tab_btn.add_css_class("active-inspector-tab");
+            colors_tab_btn.remove_css_class("active-inspector-tab");
+        } else if colors_mode {
+            inspector_stack.set_visible_child_name("colors");
             colors_tab_btn.add_css_class("active-inspector-tab");
             background_tab_btn.remove_css_class("active-inspector-tab");
         } else {
+            inspector_stack.set_visible_child_name("placeholder");
             background_tab_btn.remove_css_class("active-inspector-tab");
             colors_tab_btn.remove_css_class("active-inspector-tab");
         }
@@ -1253,6 +1250,19 @@ mod tests {
     }
 
     #[test]
+    fn background_tool_defaults_to_background_inspector_surface() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("inspector_stack.set_visible_child_name(\"background\");")
+                && production_source.contains("if background_mode {")
+                && production_source.contains("background_tab_btn.add_css_class(\"active-inspector-tab\");")
+                && production_source.contains("colors_tab_btn.remove_css_class(\"active-inspector-tab\");"),
+            "Background mode should open on the Background inspector surface instead of the Colors surface",
+        );
+    }
+
+    #[test]
     fn toolbar_color_status_label_is_center_aligned_with_swatch() {
         let source = include_str!("toolbar.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
@@ -1276,16 +1286,16 @@ mod tests {
     }
 
     #[test]
-    fn color_capable_tools_default_to_colors_inspector_surface() {
+    fn non_background_color_tools_default_to_colors_inspector_surface() {
         let source = include_str!("toolbar.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
-            production_source.contains("background_inspector.set_visible(false);")
-                && production_source.contains("colors_inspector.set_visible(colors_mode);")
+            production_source.contains("inspector_stack.set_visible_child_name(\"colors\");")
+                && production_source.contains("} else if colors_mode {")
                 && production_source.contains("Tool::Background")
                 && production_source.contains("Tool::Pen")
                 && production_source.contains("Tool::Focus"),
-            "Color-capable tools should switch the right inspector to the Colors surface",
+            "Non-background color-capable tools should switch the right inspector to the Colors surface",
         );
     }
 


### PR DESCRIPTION
## Summary
- move annotate tool-specific controls into the fixed-width right inspector and keep shared Colors integration in sync
- migrate Arrow, Text, and Number into inspector-owned primary tabs and expand Arrow with Style, Thickness, and Behavior sections
- keep toolbar color status, inspector routing, and Arrow behavior/state wiring covered by source and window regressions

## Test Plan
- cargo test capture::editor::window --lib
- cargo check