### PR TITLE
Align migrated sidepanel tool inspectors

### DIFF
--- a/docs/superpowers/specs/2026-04-09-number-side-panel-visual-consistency-design.md
+++ b/docs/superpowers/specs/2026-04-09-number-side-panel-visual-consistency-design.md
@@ -1,0 +1,88 @@
+# Number Side Panel Visual Consistency Design
+
+## Goal
+
+Make both sections of the Number tool's right inspector visually match the migrated sidepanel language used by Arrow, Text, and the other inspector panels, without changing Number behavior, routing, or sidepanel width.
+
+## Scope
+
+This design covers only the visual treatment of the Number inspector's existing `Style` and `Size` sections.
+
+Included:
+- restyling Number `Style` rows to match the migrated inspector surface language
+- restyling Number `Size` rows to match the migrated inspector surface language
+- keeping the current Number inspector width, sections, and interaction flow
+
+Excluded:
+- changing Number panel routing or tab structure
+- adding or removing Number options
+- changing Number state update behavior
+- changing the shared sidepanel width path
+- redesigning other tool panels
+
+## Current State
+
+The Number tool already routes to its own primary inspector surface with `Style` and `Size` sections.
+
+Today, those two sections do not read as visually unified:
+- `Style` uses a Number-specific row treatment
+- `Size` does not match the same migrated row language used by Arrow and Text
+
+As a result, the Number panel feels internally inconsistent and also less aligned with the other migrated tool panels.
+
+## Proposed UX
+
+When `Tool::Number` is active, both existing sections should remain in place:
+- `Style`
+- `Size`
+
+The content and order stay the same, but both sections should use the same surface language:
+- full-width option rows
+- consistent row spacing and padding
+- subtle hover surface
+- selected surface state
+- visible selected indicator
+
+No new icons or controls should be added.
+
+## Architecture
+
+The change should remain local to Number inspector row construction and Number-specific CSS.
+
+Core structure:
+- `src/capture/editor/window/mod.rs` continues to build the Number `Style` and `Size` lists
+- those lists should use the same inspector-native row composition pattern already used for the migrated sidepanel tools
+- Number-specific CSS in `src/capture/editor/ui_support.rs` should align the row surfaces with the other panels
+- the existing fixed sidepanel width path must remain unchanged
+
+## Behavior Rules
+
+- selecting a Number style must continue to use the existing Number style update path
+- selecting a Number size must continue to use the existing Number size update path
+- only the active row in each section should appear selected
+- visual updates must stay in sync when the selected Number option changes
+- no Number routing or tab-label behavior should change
+
+## Error Handling
+
+- if the current Number selection is not present in a rendered list, no incorrect row should appear selected
+- visual consistency work must not break click handling or existing Number state syncing
+- the implementation must not introduce a Number-specific sidepanel width constant
+
+## Testing
+
+Implementation should verify:
+- the Number inspector still renders `Style` and `Size`
+- both Number sections use the same migrated sidepanel surface language
+- the selected Number style row is visibly active
+- the selected Number size row is visibly active
+- Number selection behavior remains unchanged
+- sidepanel width remains unchanged
+
+## Recommended Rollout
+
+Implement in this order:
+1. Update Number inspector row construction so both sections use the same row composition model
+2. Add Number-specific CSS to align `Style` and `Size` with the other sidepanels
+3. Verify active-row syncing still works for both sections
+4. Confirm the fixed sidepanel width path remains unchanged

--- a/docs/superpowers/specs/2026-04-09-obfuscate-side-panel-design.md
+++ b/docs/superpowers/specs/2026-04-09-obfuscate-side-panel-design.md
@@ -1,0 +1,110 @@
+# Obfuscate Side Panel Design
+
+## Goal
+
+Move Obfuscate subtool selection from the top toolbar into the right inspector so the Obfuscate tool uses an inspector-native primary panel, while keeping the shared amount slider in the toolbar and removing the unused `Colors` tab for this tool.
+
+## Scope
+
+This design covers only the Obfuscate tool inspector migration.
+
+Included:
+- replacing the toolbar obfuscate method picker with a right-side Obfuscate inspector
+- showing a single `Obfuscate` tab with a `Method` section
+- preserving the current shared toolbar slider for obfuscation amount
+- removing the `Colors` tab for Obfuscate
+
+Excluded:
+- migrating the shared toolbar slider into the inspector
+- adding color controls to Obfuscate
+- changing obfuscation render behavior or method semantics
+- redesigning other tool inspectors
+
+## Current State
+
+Today, Obfuscate still behaves like a non-migrated color-capable tool in inspector routing, so it lands on the shared `Colors` surface instead of a tool-specific panel.
+
+At the same time, the actual Obfuscate-specific subtool picker still lives in the toolbar as a popover-based method control. The amount control remains on the shared toolbar slider path, which is also used by other tools and has not been migrated for them.
+
+## Proposed UX
+
+When `Tool::Obfuscate` is active, the right inspector should show a single tab:
+- `Obfuscate`
+
+There should be no secondary `Colors` tab for this tool.
+
+The `Obfuscate` tab should contain one section:
+
+### Method
+
+This section shows the existing Obfuscate subtools already supported by current editor state and rendering behavior. The section should use direct inspector option rows rather than a toolbar popover trigger.
+
+Behavior:
+- selecting an option updates the active obfuscate method immediately
+- the currently active obfuscate method is visibly selected in the inspector
+- switching between Obfuscate methods does not change the current amount-slider workflow
+
+## Interaction Model
+
+Obfuscate should split responsibilities cleanly:
+- method selection lives in the right inspector
+- amount remains on the shared toolbar slider
+
+Reasoning:
+- the slider is not Obfuscate-specific and is still shared with other tools
+- migrating only the Obfuscate-specific subtool picker keeps the inspector focused on tool-native choices
+- moving the slider only for Obfuscate would make this tool inconsistent with the rest of the editor
+
+## Architecture Impact
+
+### Inspector Routing
+
+Obfuscate should stop following the non-migrated color-tool path.
+
+Instead:
+- Obfuscate routes to its own inspector surface
+- the active tab label should be `Obfuscate`
+- no `Colors` tab should be rendered or activated for Obfuscate
+
+### Inspector Surface
+
+The Obfuscate inspector should reuse the existing shared inspector shell helpers already used by Crop, Arrow, Text, and Number:
+- same fixed sidepanel width path
+- same section framing
+- same option-row visual language used by the other migrated tool panels
+
+The tab should contain one `Method` section only.
+
+### Toolbar Changes
+
+The toolbar should stop rendering the Obfuscate-specific method picker once the sidepanel migration is complete.
+
+The shared amount slider should remain available and unchanged when Obfuscate is active.
+
+## Error Handling
+
+- Obfuscate should never fall back to the shared `Colors` tab after this migration
+- if the current Obfuscate method is missing from the rendered inspector list, no incorrect row should appear selected
+- removing the toolbar method picker must not break the existing method-update path
+- the fixed inspector width must remain on the existing shared width constant
+
+## Testing
+
+Implementation should verify:
+- Obfuscate routes to a single `Obfuscate` inspector tab
+- the `Colors` tab does not appear for Obfuscate
+- the `Obfuscate` tab renders a `Method` section
+- the section contains the existing Obfuscate subtool choices
+- selecting a method updates the active Obfuscate state immediately
+- the selected Obfuscate method is visibly active in the inspector
+- the shared toolbar slider still appears for Obfuscate and remains unchanged
+- the inspector width remains unchanged
+
+## Recommended Rollout
+
+Implement in this order:
+1. Build the Obfuscate inspector surface and routing
+2. Render Obfuscate methods as inspector-native option rows
+3. Connect selection state and method updates to the existing editor-state path
+4. Remove the toolbar Obfuscate method picker while leaving the shared slider untouched
+5. Verify that Obfuscate no longer uses the shared `Colors` tab

--- a/docs/superpowers/specs/2026-04-09-text-side-panel-visual-consistency-design.md
+++ b/docs/superpowers/specs/2026-04-09-text-side-panel-visual-consistency-design.md
@@ -1,0 +1,86 @@
+# Text Side Panel Visual Consistency Design
+
+## Goal
+
+Make the Text tool's right-inspector option rows visually match the Arrow sidepanel so the inspector feels consistent across tools, without changing Text control behavior, section order, or panel routing.
+
+## Scope
+
+This design covers only the visual treatment of Text inspector controls in the primary Text tab.
+
+Included:
+- restyling Text `Size` and `Font` option rows to match the Arrow inspector option language
+- adding a visible active-state treatment for the currently selected text size and font
+- keeping the existing Text inspector width, sections, and interaction flow
+
+Excluded:
+- changing Text inspector section order or adding new sections
+- moving controls between the toolbar and the inspector
+- changing how text size or font selection updates editor state
+- redesigning Arrow, Crop, Number, or the shared `Colors` tab
+
+## Current State
+
+The Text tool already routes to its own primary inspector surface with `Size` and `Font` sections. Unlike Arrow, those sections currently render as generic popover-list buttons with plain labels and no tool-specific active-row styling.
+
+Arrow already establishes the target visual language for inspector option rows:
+- full-width row buttons
+- subtle hover surface
+- selected surface state
+- a trailing orange check indicator for the active item
+
+## Proposed UX
+
+When `Tool::Text` is active, the `Size` and `Font` sections should keep their current content and ordering, but each option row should look like an Arrow inspector row.
+
+That means:
+- each row remains a button
+- the row fills the available inspector width
+- the option label is left-aligned
+- the active option shows the same selected-surface treatment used by Arrow
+- the active option shows a trailing orange check mark
+
+No other Text inspector structure should change.
+
+## Architecture
+
+The change should remain local to the Text inspector row construction and CSS.
+
+Core structure:
+- `src/capture/editor/window/mod.rs` continues to build the Text `Size` and `Font` lists
+- those lists should switch from plain labeled buttons to row containers that mirror Arrow's inspector row composition
+- active Text selections should be reflected through Text-specific CSS classes rather than borrowing Arrow-specific class names
+- `src/capture/editor/ui_support.rs` should define Text inspector option styles that match Arrow's visual treatment
+
+## Behavior Rules
+
+- selecting a Text size must continue to use the existing text-size update path
+- selecting a font family must continue to use the existing selected-text font update path
+- only the active Text size row should appear selected within `Size`
+- only the active font family row should appear selected within `Font`
+- switching between tools must not leak Text active-state styling into other inspectors
+
+## Error Handling
+
+- if Text state falls back to a size or font not currently in the rendered list, no incorrect row should appear selected
+- rebuilding the inspector lists must preserve correct active-row visuals after state changes and tool switches
+- visual parity work must not break button click handling or focus behavior
+
+## Testing
+
+Implementation should verify:
+- the Text inspector still renders `Size` and `Font`
+- Text option rows visually match Arrow's inspector option treatment
+- the active Text size row shows the selected state and orange check
+- the active font row shows the selected state and orange check
+- changing Text size updates both editor state and the active visual selection
+- changing font family updates both editor state and the active visual selection
+- Arrow inspector visuals remain unchanged
+
+## Recommended Rollout
+
+Implement in this order:
+1. Update Text inspector option row construction to support label-plus-check layout
+2. Add Text-specific inspector option CSS matching Arrow's visual language
+3. Wire active-state syncing for Text size and font selections
+4. Verify tool switching and repeated Text selection updates still render correctly

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1413,6 +1413,51 @@ pub fn install_editor_css() {
                 font-weight: 700;
             }
 
+            .editor-number-start-row {
+                spacing: 8px;
+            }
+
+            .editor-number-start-label {
+                color: rgba(241, 241, 243, 0.9);
+                font-size: 12px;
+                font-weight: 600;
+            }
+
+            .editor-number-start-entry {
+                min-height: 34px;
+                min-width: 48px;
+                padding: 0 10px;
+                border-radius: 8px;
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                background: rgba(255, 255, 255, 0.04);
+                color: #ffffff;
+                font-size: 12px;
+                font-weight: 700;
+                box-shadow: none;
+            }
+
+            button.editor-number-start-stepper {
+                min-width: 30px;
+                min-height: 34px;
+                padding: 0;
+                border-radius: 8px;
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                background: rgba(255, 255, 255, 0.03);
+                color: rgba(245, 245, 247, 0.92);
+                font-size: 14px;
+                font-weight: 700;
+                box-shadow: none;
+            }
+
+            button.editor-number-start-stepper:hover {
+                background: rgba(255, 255, 255, 0.07);
+                color: #ffffff;
+            }
+
+            button.editor-number-start-stepper:active {
+                background: rgba(255, 255, 255, 0.12);
+            }
+
             .editor-background-sidebar {
                 min-width: 210px;
                 padding: 16px;
@@ -2464,6 +2509,19 @@ mod tests {
                 && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
                 && !production_source.contains("NUMBER_SIDEBAR_WIDTH"),
             "Number inspector rows should match the migrated sidepanel surface language without introducing a new width path",
+        );
+    }
+
+    #[test]
+    fn number_inspector_start_controls_use_sidebar_field_styling() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains(".editor-number-start-row {\n                spacing: 8px;")
+                && production_source.contains(".editor-number-start-label {\n                color: rgba(241, 241, 243, 0.9);")
+                && production_source.contains(".editor-number-start-entry {\n                min-height: 34px;")
+                && production_source.contains("button.editor-number-start-stepper {\n                min-width: 30px;"),
+            "Number inspector start controls should be styled as inspector-native sidebar fields",
         );
     }
 

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1342,6 +1342,27 @@ pub fn install_editor_css() {
                 font-weight: 700;
             }
 
+            button.editor-text-inspector-option {
+                border-radius: 8px;
+                color: rgba(241, 241, 243, 0.9);
+            }
+
+            button.editor-text-inspector-option:hover {
+                background: rgba(255, 255, 255, 0.04);
+                color: #ffffff;
+            }
+
+            button.editor-text-inspector-option.editor-text-inspector-option-active {
+                background: rgba(255, 255, 255, 0.08);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+            }
+
+            .editor-text-inspector-check {
+                color: #ff9900;
+                font-size: 13px;
+                font-weight: 700;
+            }
+
             .editor-background-sidebar {
                 min-width: 210px;
                 padding: 16px;
@@ -2353,6 +2374,19 @@ mod tests {
             production_source.contains("button.editor-arrow-inspector-option.editor-arrow-inspector-option-active {\n                background: rgba(255, 255, 255, 0.08);")
                 && production_source.contains(".editor-arrow-inspector-check {\n                color: #ff9900;"),
             "Arrow inspector selection should use a subtle row surface plus an orange tick indicator",
+        );
+    }
+
+    #[test]
+    fn text_inspector_option_rows_match_arrow_visual_language_without_changing_panel_width() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-text-inspector-option.editor-text-inspector-option-active {\n                background: rgba(255, 255, 255, 0.08);")
+                && production_source.contains(".editor-text-inspector-check {\n                color: #ff9900;")
+                && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
+                && !production_source.contains("TEXT_SIDEBAR_WIDTH"),
+            "Text inspector rows should mirror Arrow selection styling without introducing a new sidepanel width path",
         );
     }
 

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1363,6 +1363,56 @@ pub fn install_editor_css() {
                 font-weight: 700;
             }
 
+            button.editor-obfuscate-inspector-option {
+                border-radius: 8px;
+                color: rgba(241, 241, 243, 0.9);
+            }
+
+            button.editor-obfuscate-inspector-option:hover {
+                background: rgba(255, 255, 255, 0.04);
+                color: #ffffff;
+            }
+
+            button.editor-obfuscate-inspector-option.editor-obfuscate-inspector-option-active {
+                background: rgba(255, 255, 255, 0.08);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+            }
+
+            .editor-obfuscate-inspector-check {
+                color: #ff9900;
+                font-size: 13px;
+                font-weight: 700;
+            }
+
+            button.editor-number-style-option,
+            button.editor-number-size-option {
+                border-radius: 8px;
+                color: rgba(241, 241, 243, 0.9);
+            }
+
+            button.editor-number-style-option:hover,
+            button.editor-number-size-option:hover {
+                background: rgba(255, 255, 255, 0.04);
+                color: #ffffff;
+            }
+
+            button.editor-number-style-option.editor-number-style-option-active {
+                background: rgba(255, 255, 255, 0.08);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+            }
+
+            button.editor-number-size-option.editor-number-size-option-active {
+                background: rgba(255, 255, 255, 0.08);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+            }
+
+            .editor-number-style-check,
+            .editor-number-size-check {
+                color: #ff9900;
+                font-size: 13px;
+                font-weight: 700;
+            }
+
             .editor-background-sidebar {
                 min-width: 210px;
                 padding: 16px;
@@ -2387,6 +2437,33 @@ mod tests {
                 && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
                 && !production_source.contains("TEXT_SIDEBAR_WIDTH"),
             "Text inspector rows should mirror Arrow selection styling without introducing a new sidepanel width path",
+        );
+    }
+
+    #[test]
+    fn obfuscate_inspector_option_rows_match_migrated_tool_panels_without_new_width_path() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-obfuscate-inspector-option.editor-obfuscate-inspector-option-active {\n                background: rgba(255, 255, 255, 0.08);")
+                && production_source.contains(".editor-obfuscate-inspector-check {\n                color: #ff9900;")
+                && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
+                && !production_source.contains("OBFUSCATE_SIDEBAR_WIDTH"),
+            "Obfuscate inspector rows should use the shared sidepanel language without introducing a new width path",
+        );
+    }
+
+    #[test]
+    fn number_inspector_rows_match_migrated_sidepanel_surface_language_without_new_width_path() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-number-style-option.editor-number-style-option-active {\n                background: rgba(255, 255, 255, 0.08);")
+                && production_source.contains("button.editor-number-size-option.editor-number-size-option-active {\n                background: rgba(255, 255, 255, 0.08);")
+                && production_source.contains(".editor-number-style-check,\n            .editor-number-size-check {\n                color: #ff9900;")
+                && production_source.contains(".editor-right-inspector {\n                min-width: 210px;\n                width: 210px;\n                max-width: 210px;")
+                && !production_source.contains("NUMBER_SIDEBAR_WIDTH"),
+            "Number inspector rows should match the migrated sidepanel surface language without introducing a new width path",
         );
     }
 

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -104,6 +104,37 @@ fn sync_text_option_selection(list: &GtkBox, selected_index: Option<usize>) {
     }
 }
 
+fn sync_number_option_selection(list: &GtkBox, selected_index: usize, active_class: &str) {
+    let mut child_opt = list.first_child();
+    let mut index = 0usize;
+    while let Some(child) = child_opt {
+        child_opt = child.next_sibling();
+
+        let Ok(button) = child.downcast::<Button>() else {
+            continue;
+        };
+
+        let is_active = index == selected_index;
+        if is_active {
+            button.add_css_class(active_class);
+        } else {
+            button.remove_css_class(active_class);
+        }
+
+        if let Some(content) = button.child() {
+            if let Ok(row) = content.downcast::<GtkBox>() {
+                if let Some(check_icon) = row.last_child() {
+                    if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
+                        widget.set_visible(is_active);
+                    }
+                }
+            }
+        }
+
+        index += 1;
+    }
+}
+
 pub(super) struct EventContext {
     pub app: Application,
     pub window: ApplicationWindow,
@@ -1083,32 +1114,19 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         let state_style = state_number_style.clone();
         let drawing_area_style = drawing_area_number_style.clone();
         let refresh_display = refresh_number_start_display_style.clone();
+        let number_options_list_sync = number_options_list.clone();
 
-        button.connect_clicked(move |b| {
+        button.connect_clicked(move |_| {
             {
                 let mut st = state_style.lock().unwrap();
                 st.numbering_style = style;
                 st.next_number = st.numbering_start;
             }
-
-            if let Some(list) = b.parent() {
-                let mut child = list.first_child();
-                while let Some(c) = child {
-                    child = c.next_sibling();
-                    if let Ok(btn) = c.downcast::<Button>() {
-                        if let Some(box_child) = btn.child() {
-                            if let Ok(hbox) = box_child.downcast::<GtkBox>() {
-                                if let Some(icon) = hbox.first_child() {
-                                    if let Ok(img) = icon.downcast::<Image>() {
-                                        img.set_visible(btn == *b);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
+            sync_number_option_selection(
+                &number_options_list_sync,
+                style_idx - 1,
+                "editor-number-style-option-active",
+            );
             refresh_display();
 
             if let Some(area) = drawing_area_style.upgrade() {
@@ -1171,12 +1189,19 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         let state_size = state_number_size.clone();
         let drawing_area_size = drawing_area_number_size.clone();
         let number_size_btn = number_size_button.clone();
+        let number_size_list_sync = number_size_list.clone();
 
         button.connect_clicked(move |b| {
             {
                 let mut st = state_size.lock().unwrap();
                 st.number_size = size;
             }
+
+            sync_number_option_selection(
+                &number_size_list_sync,
+                size_idx - 1,
+                "editor-number-size-option-active",
+            );
 
             // Close the size popover
             if let Some(popover) = b.ancestor(Popover::static_type()) {

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -31,6 +31,8 @@ use super::super::{
 const MOVE_HANDLE_DRAG_RADIUS: f64 = 10.0;
 const RESIZE_HANDLE_DRAG_SIZE: f64 = 18.0;
 const ARROW_CLICK_NOOP_DISTANCE: f64 = 3.0;
+const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
+const TEXT_FONT_FAMILIES: [&str; 5] = ["Sans", "Serif", "Monospace", "Fantasy", "Cursive"];
 use super::super::pen_weight::{HighlighterMode, PenWeight};
 use super::{
     canvas::{
@@ -62,6 +64,37 @@ fn sync_arrow_option_selection(list: &GtkBox, selected_index: usize) {
                 if let Some(check_icon) = row.last_child() {
                     if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
                         widget.set_visible(index == selected_index);
+                    }
+                }
+            }
+        }
+
+        index += 1;
+    }
+}
+
+fn sync_text_option_selection(list: &GtkBox, selected_index: Option<usize>) {
+    let mut child_opt = list.first_child();
+    let mut index = 0usize;
+    while let Some(child) = child_opt {
+        child_opt = child.next_sibling();
+
+        let Ok(button) = child.downcast::<Button>() else {
+            continue;
+        };
+
+        let is_active = selected_index == Some(index);
+        if is_active {
+            button.add_css_class("editor-text-inspector-option-active");
+        } else {
+            button.remove_css_class("editor-text-inspector-option-active");
+        }
+
+        if let Some(content) = button.child() {
+            if let Ok(row) = content.downcast::<GtkBox>() {
+                if let Some(check_icon) = row.last_child() {
+                    if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
+                        widget.set_visible(is_active);
                     }
                 }
             }
@@ -109,6 +142,8 @@ pub(super) struct EventContext {
     pub size_slider: Scale,
     pub text_size_label: Label,
     pub font_family_label: Label,
+    pub text_size_list: gtk4::Box,
+    pub font_family_list: gtk4::Box,
     pub apply_crop_btn: Button,
     pub crop_reset_btn: Button,
 
@@ -188,6 +223,8 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         size_slider,
         text_size_label,
         font_family_label,
+        text_size_list,
+        font_family_list,
         apply_crop_btn,
         crop_reset_btn,
         undo_btn,
@@ -1219,12 +1256,9 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
 
     let state_apply_crop = state.clone();
     let drawing_area_apply_crop = drawing_area.downgrade();
-    let buttons_apply_crop = tool_buttons.clone();
     let apply_crop_btn_click = apply_crop_btn.clone();
     let update_canvas_content_size_apply = update_canvas_content_size.clone();
-    let update_toolbar_for_tool_apply_crop = update_toolbar_for_tool.clone();
     let update_crop_size_fields_apply_crop = update_crop_size_fields.clone();
-    let sync_picker_for_active_tool_apply_crop = sync_picker_for_active_tool.clone();
     apply_crop_btn.connect_clicked(move |_| {
         let apply_result = {
             let mut st = state_apply_crop.lock().unwrap();
@@ -2022,6 +2056,8 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let sync_size_control_canvas_click = sync_size_control.clone();
     let text_size_label_click = text_size_label.clone();
     let font_family_label_click = font_family_label.clone();
+    let text_size_list_click = text_size_list.clone();
+    let font_family_list_click = font_family_list.clone();
     click.connect_pressed(move |_gesture, n_press, x, y| {
         let t = *transform_click.lock().unwrap();
         let view_point = Point { x, y };
@@ -2253,9 +2289,21 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
                 sync_size_control_canvas_click();
                 if let Some(size) = selected_text_size {
                     text_size_label_click.set_label(&format!("{}pt", size as i32));
+                    sync_text_option_selection(
+                        &text_size_list_click,
+                        TEXT_SIZE_OPTIONS
+                            .iter()
+                            .position(|candidate| *candidate == size as i32),
+                    );
                 }
                 if let Some(family) = selected_font_family {
                     font_family_label_click.set_label(&family);
+                    sync_text_option_selection(
+                        &font_family_list_click,
+                        TEXT_FONT_FAMILIES
+                            .iter()
+                            .position(|candidate| *candidate == family.as_str()),
+                    );
                 }
 
                 if let Some(index) = selected_color_index {
@@ -2393,6 +2441,18 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
 
                 text_size_label_click.set_label(&format!("{}pt", text_size as i32));
                 font_family_label_click.set_label(&font_family);
+                sync_text_option_selection(
+                    &text_size_list_click,
+                    TEXT_SIZE_OPTIONS
+                        .iter()
+                        .position(|candidate| *candidate == text_size as i32),
+                );
+                sync_text_option_selection(
+                    &font_family_list_click,
+                    TEXT_FONT_FAMILIES
+                        .iter()
+                        .position(|candidate| *candidate == font_family.as_str()),
+                );
 
                 if let Some(area) = drawing_area_click.upgrade() {
                     area.grab_focus();

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -82,6 +82,9 @@ use super::ui_support::{
     toolbar_icon_size,
 };
 
+const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
+const TEXT_FONT_FAMILIES: [&str; 5] = ["Sans", "Serif", "Monospace", "Fantasy", "Cursive"];
+
 fn sync_arrow_option_selection(list: &GtkBox, selected_index: usize) {
     let mut child_opt = list.first_child();
     let mut index = 0usize;
@@ -131,6 +134,36 @@ fn sync_crop_option_selection(list: &GtkBox, selected_index: usize) {
                 if let Some(check_icon) = row.last_child() {
                     if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
                         widget.set_visible(index == selected_index);
+                    }
+                }
+            }
+        }
+
+        index += 1;
+    }
+}
+
+fn sync_text_option_selection(list: &GtkBox, selected_index: Option<usize>) {
+    let mut child_opt = list.first_child();
+    let mut index = 0usize;
+    while let Some(child) = child_opt {
+        child_opt = child.next_sibling();
+        let Ok(button) = child.downcast::<Button>() else {
+            continue;
+        };
+
+        let is_active = selected_index == Some(index);
+        if is_active {
+            button.add_css_class("editor-text-inspector-option-active");
+        } else {
+            button.remove_css_class("editor-text-inspector-option-active");
+        }
+
+        if let Some(content) = button.child() {
+            if let Ok(row) = content.downcast::<GtkBox>() {
+                if let Some(check_icon) = row.last_child() {
+                    if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
+                        widget.set_visible(is_active);
                     }
                 }
             }
@@ -1435,18 +1468,52 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         });
     }
 
+    let (selected_text_size, selected_font_family) = {
+        let st = state.lock().unwrap();
+        (
+            st.selected_text_action_size().map(|size| size as i32).unwrap_or(st.text_size as i32),
+            st.selected_text_font_family()
+                .unwrap_or_else(|| st.text_font_family.clone()),
+        )
+    };
+
     while let Some(child) = text_size_list.first_child() {
         text_size_list.remove(&child);
     }
-    for size in [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72] {
+    for size in TEXT_SIZE_OPTIONS {
         let label = format!("{}pt", size);
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let label_widget = Label::new(Some(&label));
+        label_widget.set_hexpand(true);
+        label_widget.set_xalign(0.0);
+
+        let check_icon = Label::new(Some("✓"));
+        check_icon.set_visible(size == selected_text_size);
+        check_icon.add_css_class("editor-text-inspector-check");
+
+        btn_box.append(&label_widget);
+        btn_box.append(&check_icon);
+
         let btn = Button::builder()
-            .label(&label)
             .has_frame(false)
-            .css_classes(["editor-popover-list-item", "flat"])
+            .css_classes([
+                "editor-popover-list-item",
+                "flat",
+                "editor-text-inspector-option",
+            ])
+            .child(&btn_box)
             .build();
+        if size == selected_text_size {
+            btn.add_css_class("editor-text-inspector-option-active");
+        }
         let state = state.clone();
         let text_size_label = text_size_label.clone();
+        let text_size_list_sync = text_size_list.clone();
         let drawing_area = drawing_area.clone();
         btn.connect_clicked(move |b| {
             if let Some(popover) = b.ancestor(Popover::static_type()) {
@@ -1460,6 +1527,10 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                 st.text_size = size as f64;
             }
             drop(st);
+            sync_text_option_selection(
+                &text_size_list_sync,
+                TEXT_SIZE_OPTIONS.iter().position(|candidate| *candidate == size),
+            );
             if has_active_text {
                 drawing_area.grab_focus();
             }
@@ -1471,14 +1542,39 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     while let Some(child) = font_family_list.first_child() {
         font_family_list.remove(&child);
     }
-    for family in ["Sans", "Serif", "Monospace", "Fantasy", "Cursive"] {
+    for family in TEXT_FONT_FAMILIES {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let label_widget = Label::new(Some(family));
+        label_widget.set_hexpand(true);
+        label_widget.set_xalign(0.0);
+
+        let check_icon = Label::new(Some("✓"));
+        check_icon.set_visible(family == selected_font_family);
+        check_icon.add_css_class("editor-text-inspector-check");
+
+        btn_box.append(&label_widget);
+        btn_box.append(&check_icon);
+
         let btn = Button::builder()
-            .label(family)
             .has_frame(false)
-            .css_classes(["editor-popover-list-item", "flat"])
+            .css_classes([
+                "editor-popover-list-item",
+                "flat",
+                "editor-text-inspector-option",
+            ])
+            .child(&btn_box)
             .build();
+        if family == selected_font_family {
+            btn.add_css_class("editor-text-inspector-option-active");
+        }
         let state = state.clone();
         let font_family_label = font_family_label.clone();
+        let font_family_list_sync = font_family_list.clone();
         let drawing_area = drawing_area.clone();
         let family_str = family.to_string();
         btn.connect_clicked(move |b| {
@@ -1495,6 +1591,12 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                 st.text_font_family = family_str.clone();
             }
             drop(st);
+            sync_text_option_selection(
+                &font_family_list_sync,
+                TEXT_FONT_FAMILIES
+                    .iter()
+                    .position(|candidate| *candidate == family_str.as_str()),
+            );
             if has_active_text {
                 drawing_area.grab_focus();
             }
@@ -1765,6 +1867,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         let size_slider = size_slider.clone();
         let text_size_label = text_size_label.clone();
         let font_family_label = font_family_label.clone();
+        let text_size_list = text_size_list.clone();
+        let font_family_list = font_family_list.clone();
         move || {
             // Extract all needed data BEFORE any GTK operations to avoid deadlock
             let (selected_tool, mode, value, text_size, font_family) = {
@@ -1780,6 +1884,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
             text_size_label.set_label(&format!("{}pt", text_size as i32));
             font_family_label.set_label(&font_family);
+            sync_text_option_selection(&text_size_list, TEXT_SIZE_OPTIONS.iter().position(|candidate| *candidate == text_size as i32));
+            sync_text_option_selection(&font_family_list, TEXT_FONT_FAMILIES.iter().position(|candidate| *candidate == font_family.as_str()));
 
             // Now perform GTK operations WITHOUT holding the lock
             if selected_tool == Tool::Highlighter {
@@ -2598,6 +2704,8 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         size_slider: size_slider.clone(),
         text_size_label: text_size_label.clone(),
         font_family_label: font_family_label.clone(),
+        text_size_list: text_size_list.clone(),
+        font_family_list: font_family_list.clone(),
         apply_crop_btn: crop_apply_btn.clone(),
         crop_reset_btn: crop_reset_btn.clone(),
         undo_btn: undo_btn.clone(),
@@ -2850,6 +2958,21 @@ mod tests {
                 && production_source.contains("sync_arrow_option_selection(&arrow_style_list, selected_style);")
                 && production_source.contains("sync_arrow_option_selection(&arrow_thickness_list, selected_thickness);"),
             "Arrow inspector rows should expose a visible selected tick for style and thickness options",
+        );
+    }
+
+    #[test]
+    fn text_inspector_rows_use_label_plus_tick_layout_and_shared_sidebar_width() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("check_icon.add_css_class(\"editor-text-inspector-check\");")
+                && production_source.contains("btn.add_css_class(\"editor-text-inspector-option-active\");")
+                && production_source.contains("sync_text_option_selection(&text_size_list")
+                && production_source.contains("sync_text_option_selection(&font_family_list")
+                && production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("TEXT_SIDEBAR_WIDTH"),
+            "Text inspector rows should use explicit selected ticks while reusing the existing fixed sidebar width",
         );
     }
 }

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -2,7 +2,7 @@ use gdk4x11::X11Surface;
 use gtk4::gdk;
 use gtk4::{
     glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton,
-    DrawingArea, Entry, Image, Label, Orientation, Popover, Stack,
+    DrawingArea, Entry, Label, Orientation, Popover, Stack,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
@@ -84,6 +84,12 @@ use super::ui_support::{
 
 const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
 const TEXT_FONT_FAMILIES: [&str; 5] = ["Sans", "Serif", "Monospace", "Fantasy", "Cursive"];
+const OBFUSCATE_METHOD_OPTIONS: [(super::types::ObfuscateMethod, &str); 4] = [
+    (super::types::ObfuscateMethod::Pixelate, "Pixelate"),
+    (super::types::ObfuscateMethod::BlurSecure, "Blur (Secure)"),
+    (super::types::ObfuscateMethod::BlurSmooth, "Blur (Smooth)"),
+    (super::types::ObfuscateMethod::Blackout, "Blackout"),
+];
 
 fn sync_arrow_option_selection(list: &GtkBox, selected_index: usize) {
     let mut child_opt = list.first_child();
@@ -164,6 +170,35 @@ fn sync_text_option_selection(list: &GtkBox, selected_index: Option<usize>) {
                 if let Some(check_icon) = row.last_child() {
                     if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
                         widget.set_visible(is_active);
+                    }
+                }
+            }
+        }
+
+        index += 1;
+    }
+}
+
+fn sync_obfuscate_option_selection(list: &GtkBox, selected_index: usize) {
+    let mut child_opt = list.first_child();
+    let mut index = 0usize;
+    while let Some(child) = child_opt {
+        child_opt = child.next_sibling();
+        let Ok(button) = child.downcast::<Button>() else {
+            continue;
+        };
+
+        if index == selected_index {
+            button.add_css_class("editor-obfuscate-inspector-option-active");
+        } else {
+            button.remove_css_class("editor-obfuscate-inspector-option-active");
+        }
+
+        if let Some(content) = button.child() {
+            if let Ok(row) = content.downcast::<GtkBox>() {
+                if let Some(check_icon) = row.last_child() {
+                    if let Ok(widget) = check_icon.downcast::<gtk4::Widget>() {
+                        widget.set_visible(index == selected_index);
                     }
                 }
             }
@@ -477,7 +512,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         obfuscate_method_group,
         obfuscate_method_button,
         obfuscate_method_popover: _,
-        obfuscate_method_list,
+        obfuscate_method_list: _toolbar_obfuscate_method_list,
         pen_weight_button,
         pen_weight_popover: _,
         pen_weight_list,
@@ -715,25 +750,30 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let text_size_list = GtkBox::new(Orientation::Vertical, 0);
     let font_family_list = GtkBox::new(Orientation::Vertical, 0);
+    let obfuscate_method_list = GtkBox::new(Orientation::Vertical, 0);
 
-    let number_options_list = GtkBox::new(Orientation::Vertical, 4);
+    let number_options_list = GtkBox::new(Orientation::Vertical, 0);
     number_options_list.set_margin_start(4);
     number_options_list.set_margin_end(4);
     number_options_list.set_margin_top(4);
     number_options_list.set_margin_bottom(4);
     for style in super::numbering_style::NumberingStyle::ALL {
         let btn_box = GtkBox::new(Orientation::Horizontal, 8);
-        let check_icon = Image::from_icon_name(icon_names::SELECT);
-        check_icon.set_pixel_size(12);
-        check_icon.set_visible(style == super::numbering_style::NumberingStyle::default());
-        check_icon.add_css_class("editor-number-style-check");
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
 
         let label = Label::new(Some(style.label()));
         label.set_hexpand(true);
-        label.set_halign(gtk4::Align::Start);
+        label.set_xalign(0.0);
 
-        btn_box.append(&check_icon);
+        let check_icon = Label::new(Some("✓"));
+        check_icon.set_visible(style == super::numbering_style::NumberingStyle::default());
+        check_icon.add_css_class("editor-number-style-check");
+
         btn_box.append(&label);
+        btn_box.append(&check_icon);
 
         let btn = Button::builder()
             .has_frame(false)
@@ -744,6 +784,9 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
             ])
             .child(&btn_box)
             .build();
+        if style == super::numbering_style::NumberingStyle::default() {
+            btn.add_css_class("editor-number-style-option-active");
+        }
         number_options_list.append(&btn);
     }
 
@@ -758,15 +801,35 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let number_size_list = GtkBox::new(Orientation::Vertical, 0);
     for size in super::numbering_style::NumberSize::ALL {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let label = Label::new(Some(size.label()));
+        label.set_hexpand(true);
+        label.set_xalign(0.0);
+
+        let check_icon = Label::new(Some("✓"));
+        check_icon.set_visible(size == super::numbering_style::NumberSize::default());
+        check_icon.add_css_class("editor-number-size-check");
+
+        btn_box.append(&label);
+        btn_box.append(&check_icon);
+
         let btn = Button::builder()
-            .label(size.label())
             .has_frame(false)
             .css_classes([
                 "editor-popover-list-item",
                 "flat",
                 "editor-number-size-option",
             ])
+            .child(&btn_box)
             .build();
+        if size == super::numbering_style::NumberSize::default() {
+            btn.add_css_class("editor-number-size-option-active");
+        }
         number_size_list.append(&btn);
     }
 
@@ -1217,6 +1280,14 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     append_inspector_section(&text_inspector_content, "Size", text_size_list.upcast_ref());
     append_inspector_section(&text_inspector_content, "Font", font_family_list.upcast_ref());
 
+    let (obfuscate_inspector, obfuscate_inspector_content) = build_tool_inspector();
+    obfuscate_method_list.add_css_class("editor-inspector-option-list");
+    append_inspector_section(
+        &obfuscate_inspector_content,
+        "Method",
+        obfuscate_method_list.upcast_ref(),
+    );
+
     let (number_inspector, number_inspector_content) = build_tool_inspector();
     number_options_list.add_css_class("editor-inspector-option-list");
     number_size_list.add_css_class("editor-inspector-option-list");
@@ -1257,6 +1328,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     crop_inspector.set_visible(true);
     arrow_inspector.set_visible(true);
     text_inspector.set_visible(true);
+    obfuscate_inspector.set_visible(true);
     number_inspector.set_visible(true);
     colors_inspector.set_visible(true);
     placeholder_inspector.set_visible(true);
@@ -1264,6 +1336,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     inspector_stack.add_named(&crop_inspector, Some("crop"));
     inspector_stack.add_named(&arrow_inspector, Some("arrow"));
     inspector_stack.add_named(&text_inspector, Some("text"));
+    inspector_stack.add_named(&obfuscate_inspector, Some("obfuscate"));
     inspector_stack.add_named(&number_inspector, Some("number"));
     inspector_stack.add_named(&colors_inspector, Some("colors"));
     inspector_stack.add_named(&placeholder_inspector, Some("placeholder"));
@@ -1605,6 +1678,59 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         font_family_list.append(&btn);
     }
 
+    while let Some(child) = obfuscate_method_list.first_child() {
+        obfuscate_method_list.remove(&child);
+    }
+    let selected_obfuscate_method = {
+        let st = state.lock().unwrap();
+        st.obfuscate_method()
+    };
+    for (index, (method, label)) in OBFUSCATE_METHOD_OPTIONS.iter().enumerate() {
+        let btn_box = GtkBox::new(Orientation::Horizontal, 8);
+        btn_box.set_margin_start(8);
+        btn_box.set_margin_end(8);
+        btn_box.set_margin_top(4);
+        btn_box.set_margin_bottom(4);
+
+        let label_widget = Label::new(Some(label));
+        label_widget.set_hexpand(true);
+        label_widget.set_xalign(0.0);
+
+        let check_icon = Label::new(Some("✓"));
+        check_icon.set_visible(*method == selected_obfuscate_method);
+        check_icon.add_css_class("editor-obfuscate-inspector-check");
+
+        btn_box.append(&label_widget);
+        btn_box.append(&check_icon);
+
+        let btn = Button::builder()
+            .has_frame(false)
+            .css_classes([
+                "editor-popover-list-item",
+                "flat",
+                "editor-obfuscate-inspector-option",
+            ])
+            .child(&btn_box)
+            .build();
+        if *method == selected_obfuscate_method {
+            btn.add_css_class("editor-obfuscate-inspector-option-active");
+        }
+
+        let state = state.clone();
+        let drawing_area = drawing_area.clone();
+        let obfuscate_method_list_sync = obfuscate_method_list.clone();
+        btn.connect_clicked(move |_| {
+            {
+                let mut st = state.lock().unwrap();
+                st.set_obfuscate_method(*method);
+            }
+            sync_obfuscate_option_selection(&obfuscate_method_list_sync, index);
+            drawing_area.queue_draw();
+        });
+
+        obfuscate_method_list.append(&btn);
+    }
+
     let eyedropper_mode = Rc::new(Cell::new(false));
     let eyedropper_from_sidebar = Rc::new(Cell::new(false));
     let eyedropper_point = Rc::new(RefCell::new(None::<Point>));
@@ -1869,9 +1995,10 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         let font_family_label = font_family_label.clone();
         let text_size_list = text_size_list.clone();
         let font_family_list = font_family_list.clone();
+        let obfuscate_method_list = obfuscate_method_list.clone();
         move || {
             // Extract all needed data BEFORE any GTK operations to avoid deadlock
-            let (selected_tool, mode, value, text_size, font_family) = {
+            let (selected_tool, mode, value, text_size, font_family, obfuscate_method) = {
                 let st = state.lock().unwrap();
                 (
                     st.selected_tool,
@@ -1879,6 +2006,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                     st.active_size_value().unwrap_or_default(),
                     st.text_size,
                     st.text_font_family.clone(),
+                    st.obfuscate_method(),
                 )
             };
 
@@ -1886,6 +2014,12 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
             font_family_label.set_label(&font_family);
             sync_text_option_selection(&text_size_list, TEXT_SIZE_OPTIONS.iter().position(|candidate| *candidate == text_size as i32));
             sync_text_option_selection(&font_family_list, TEXT_FONT_FAMILIES.iter().position(|candidate| *candidate == font_family.as_str()));
+            if let Some(selected_method) = OBFUSCATE_METHOD_OPTIONS
+                .iter()
+                .position(|(method, _)| *method == obfuscate_method)
+            {
+                sync_obfuscate_option_selection(&obfuscate_method_list, selected_method);
+            }
 
             // Now perform GTK operations WITHOUT holding the lock
             if selected_tool == Tool::Highlighter {
@@ -2975,4 +3109,46 @@ mod tests {
             "Text inspector rows should use explicit selected ticks while reusing the existing fixed sidebar width",
         );
     }
+
+    #[test]
+    fn obfuscate_inspector_renders_method_section_and_reuses_shared_sidebar_width() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let (obfuscate_inspector, obfuscate_inspector_content) = build_tool_inspector();")
+                && production_source.contains("\"Method\"")
+                && production_source.contains("sync_obfuscate_option_selection(&obfuscate_method_list")
+                && production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("OBFUSCATE_SIDEBAR_WIDTH"),
+            "Obfuscate should render a Method section while reusing the shared fixed sidebar width",
+        );
+    }
+
+    #[test]
+    fn obfuscate_inspector_uses_a_fresh_list_instead_of_reusing_toolbar_popover_state() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let obfuscate_method_list = GtkBox::new(Orientation::Vertical, 0);")
+                && !production_source.contains("if let Some(parent) = obfuscate_method_list.parent() {"),
+            "Obfuscate should follow the migrated tool pattern and build a fresh inspector-owned list instead of reusing toolbar popover state",
+        );
+    }
+
+    #[test]
+    fn number_inspector_style_and_size_rows_use_matching_row_composition() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("editor-number-style-check")
+                && production_source.contains("editor-number-size-check")
+                && production_source.contains("editor-number-style-option-active")
+                && production_source.contains("editor-number-size-option-active")
+                && production_source.contains("sync_number_option_selection(")
+                && production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
+                && !production_source.contains("NUMBER_SIDEBAR_WIDTH"),
+            "Number Style and Size rows should share the same inspector-native composition while reusing the shared sidebar width",
+        );
+    }
+
 }

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -797,7 +797,20 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     number_start_entry.set_editable(false);
     number_start_entry.add_css_class("editor-number-start-entry");
     let number_inc_btn = Button::with_label("+");
+    number_inc_btn.add_css_class("editor-number-start-stepper");
     let number_dec_btn = Button::with_label("-");
+    number_dec_btn.add_css_class("editor-number-start-stepper");
+
+    let number_start_row = GtkBox::new(Orientation::Horizontal, 8);
+    number_start_row.add_css_class("editor-number-start-row");
+    let number_start_label = Label::new(Some("Start with:"));
+    number_start_label.add_css_class("editor-number-start-label");
+    number_start_label.set_hexpand(true);
+    number_start_label.set_xalign(0.0);
+    number_start_row.append(&number_start_label);
+    number_start_row.append(&number_dec_btn);
+    number_start_row.append(&number_start_entry);
+    number_start_row.append(&number_inc_btn);
 
     let number_size_list = GtkBox::new(Orientation::Vertical, 0);
     for size in super::numbering_style::NumberSize::ALL {
@@ -1292,6 +1305,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     number_options_list.add_css_class("editor-inspector-option-list");
     number_size_list.add_css_class("editor-inspector-option-list");
     append_inspector_section(&number_inspector_content, "Style", number_options_list.upcast_ref());
+    append_inspector_section(&number_inspector_content, "Start", number_start_row.upcast_ref());
     append_inspector_section(&number_inspector_content, "Size", number_size_list.upcast_ref());
 
     let inspector_tabs = GtkBox::new(Orientation::Horizontal, 8);
@@ -3148,6 +3162,21 @@ mod tests {
                 && production_source.contains("root.set_width_request(BACKGROUND_SIDEBAR_WIDTH);")
                 && !production_source.contains("NUMBER_SIDEBAR_WIDTH"),
             "Number Style and Size rows should share the same inspector-native composition while reusing the shared sidebar width",
+        );
+    }
+
+    #[test]
+    fn number_inspector_includes_start_controls_in_the_sidebar() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("let number_start_row = GtkBox::new(Orientation::Horizontal, 8);")
+                && production_source.contains("let number_start_label = Label::new(Some(\"Start with:\"));")
+                && production_source.contains("number_start_row.append(&number_dec_btn);")
+                && production_source.contains("number_start_row.append(&number_start_entry);")
+                && production_source.contains("number_start_row.append(&number_inc_btn);")
+                && production_source.contains("append_inspector_section(&number_inspector_content, \"Start\", number_start_row.upcast_ref());"),
+            "Number inspector should expose the starting number controls inside the sidebar",
         );
     }
 

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -1027,8 +1027,7 @@ pub(super) fn build_toolbar_right_controls(
         text_size_group.set_visible(is_text_tool);
         font_family_group.set_visible(is_text_tool);
 
-        let is_obfuscate_tool = matches!(tool, Tool::Obfuscate);
-        obfuscate_method_group.set_visible(is_obfuscate_tool);
+        obfuscate_method_group.set_visible(false);
 
         let is_highlighter_tool = matches!(tool, Tool::Highlighter);
         let is_pen_tool = matches!(tool, Tool::Pen);
@@ -1053,6 +1052,7 @@ pub(super) fn build_toolbar_right_controls(
             Tool::Crop => Some(("Crop", "crop")),
             Tool::Arrow => Some(("Arrow", "arrow")),
             Tool::Text => Some(("Text", "text")),
+            Tool::Obfuscate => Some(("Obfuscate", "obfuscate")),
             Tool::Number => Some(("Number", "number")),
             _ => None,
         };
@@ -1069,7 +1069,6 @@ pub(super) fn build_toolbar_right_controls(
                 | Tool::Text
                 | Tool::Number
                 | Tool::Highlighter
-                | Tool::Obfuscate
                 | Tool::Focus
         );
         background_tab_btn.set_label(primary_surface.map(|(label, _)| label).unwrap_or("Background"));
@@ -1174,11 +1173,22 @@ mod tests {
                 && production_source.contains("} else if colors_mode {")
                 && production_source.contains("Tool::Pen")
                 && production_source.contains("Tool::Line")
-                && production_source.contains("Tool::Obfuscate")
                 && !production_source.contains("Tool::Arrow => Some((\"Arrow\", \"colors\"))")
                 && !production_source.contains("Tool::Text => Some((\"Text\", \"colors\"))")
-                && !production_source.contains("Tool::Number => Some((\"Number\", \"colors\"))"),
+                && !production_source.contains("Tool::Number => Some((\"Number\", \"colors\"))")
+                && !production_source.contains("| Tool::Obfuscate"),
             "Non-migrated color-capable tools should still switch the right inspector to the Colors surface",
+        );
+    }
+
+    #[test]
+    fn obfuscate_routes_to_a_dedicated_primary_tab_instead_of_shared_colors() {
+        let source = include_str!("toolbar.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("Tool::Obfuscate => Some((\"Obfuscate\", \"obfuscate\"))")
+                && !production_source.contains("| Tool::Obfuscate"),
+            "Obfuscate should stop using the shared Colors inspector flow and route to its own primary tab",
         );
     }
 
@@ -1203,8 +1213,9 @@ mod tests {
             !production_source.contains("standard_mode_group.append(&arrow_style_group);")
                 && !production_source.contains("standard_mode_group.append(&number_options_group);")
                 && !production_source.contains("root.append(&text_size_group);")
-                && !production_source.contains("root.append(&font_family_group);"),
-            "Toolbar layout should stop mounting Arrow, Text, and Number detail groups after the inspector migration",
+                && !production_source.contains("root.append(&font_family_group);")
+                && !production_source.contains("obfuscate_method_group.set_visible(is_obfuscate_tool);"),
+            "Toolbar layout should stop mounting Arrow, Text, Number, and Obfuscate detail groups after the inspector migration",
         );
     }
 


### PR DESCRIPTION
## Summary
- align the text and number inspector rows with the migrated sidepanel surface styling
- migrate obfuscate to its dedicated sidebar inspector and restore the number start controls
- keep the shared sidepanel width path unchanged and leave the shared toolbar slider behavior in place

## Verification
- cargo test number_inspector_style_and_size_rows_use_matching_row_composition --lib
- cargo test number_inspector_rows_match_migrated_sidepanel_surface_language_without_new_width_path --lib
- cargo test number_inspector_includes_start_controls_in_the_sidebar --lib
- cargo test number_inspector_start_controls_use_sidebar_field_styling --lib
- cargo check