### PR TITLE
feat(editor): add footer zoom controls and full editor panel improvements

### DIFF
--- a/docs/superpowers/specs/2026-04-10-editor-footer-zoom-popover-design.md
+++ b/docs/superpowers/specs/2026-04-10-editor-footer-zoom-popover-design.md
@@ -1,0 +1,112 @@
+# Editor Footer Zoom Popover Design
+
+## Goal
+
+Replace the editor footer pin control with a zoom trigger that shows the current zoom percentage and opens a compact zoom popover inside the editor canvas area.
+
+## Scope
+
+This design covers only the footer zoom trigger and its anchored popover in the screenshot editor.
+
+Included:
+- replacing the footer pin button with a zoom percentage trigger
+- opening a compact popover above the footer trigger, inside the editor surface
+- adding `Zoom In`, `Zoom Out`, and `Fit to Screen` actions
+- showing instructional rows for scroll-wheel zoom and right-button pan
+- styling the popover with the same surface language as the migrated side panels, without turning it into a full-height panel
+
+Excluded:
+- changing toolbar traffic-light zoom behavior
+- adding a persistent zoom side panel
+- changing the editor's overall footer layout beyond the left control swap
+- adding new canvas navigation modes beyond the existing zoom and pan behavior
+
+## Current State
+
+The footer left slot is currently occupied by a pin button built in `src/capture/editor/window/footer.rs`.
+
+The editor already maintains canvas zoom state through the shared view transform, and the codebase already uses GTK popovers for compact option surfaces in the toolbar. The existing side panels also provide the visual language the new popover should borrow from.
+
+## Proposed UX
+
+The footer's left control becomes a text-based zoom trigger such as `100%`.
+
+When clicked:
+- a popover appears above the trigger, not below it
+- the popover stays visually inside the editor, anchored in the bottom-left canvas region rather than extending outside the editor shell
+- the popover is only as tall and wide as needed to fit its content
+
+Popover content:
+- `Zoom In`
+- `Zoom Out`
+- `Fit to Screen`
+- `Zoom with the scroll wheel`
+- `Pan with the right button`
+
+Interaction rules:
+- the footer trigger shows only the current zoom percentage
+- `Zoom In` increases zoom in fixed steps
+- `Zoom Out` decreases zoom in fixed steps
+- `Fit to Screen` restores the fitted canvas transform for the current editor viewport
+- the last two rows are instructional only and are not clickable
+- whenever zoom changes, the footer percentage updates to match the current view transform
+
+## Architecture
+
+The change should stay localized to the editor footer and event wiring.
+
+Core structure:
+- `src/capture/editor/window/footer.rs` builds a dedicated zoom trigger and anchored popover instead of the current pin control
+- `src/capture/editor/window/events.rs` wires trigger clicks and zoom actions, and keeps the zoom percentage label in sync with the active transform
+- `src/capture/editor/window/mod.rs` continues to pass footer parts into the editor event context with the new zoom-specific fields
+- `src/capture/editor/ui_support.rs` provides any needed footer button or popover CSS so the popover visually matches the side-panel surface language while remaining compact
+
+Placement model:
+- the popover should be parented and positioned from the footer zoom trigger
+- the popover should render upward from the footer trigger so it stays above the control
+- the popover surface should remain bounded to compact menu-like dimensions rather than inheriting side-panel height or width behavior
+
+## Styling
+
+The zoom popover should visually read as part of the editor's migrated inspector system, but in a smaller popup form.
+
+Styling requirements:
+- reuse the restrained side-panel surface language for background, border radius, border, spacing, and hover states
+- do not reuse any full-height or fixed-width side-panel layout behavior
+- keep the popover compact, with enough room for all five rows and no unnecessary empty space
+- preserve a clear distinction between clickable action rows and non-clickable instructional rows
+- maintain alignment and spacing that feel consistent with the rest of the editor UI
+
+## Behavior Rules
+
+- clicking the footer zoom percentage toggles or opens the zoom popover
+- clicking `Zoom In`, `Zoom Out`, or `Fit to Screen` applies the change immediately
+- action rows should close the popover after activation unless keeping it open proves necessary for repeated zoom actions
+- instructional rows must not mutate editor state
+- the zoom label must always reflect the latest effective zoom percentage shown on canvas
+
+## Error Handling
+
+- if the editor cannot compute a valid fitted transform, `Fit to Screen` should leave the current transform unchanged rather than applying a broken state
+- zoom actions must clamp to safe scale limits so repeated clicks cannot produce unusable values
+- if the popover cannot be positioned above the trigger, it should still stay attached to the zoom control rather than detaching into a free-floating overlay
+
+## Testing
+
+Implementation should verify:
+- the footer pin control is replaced by a zoom percentage trigger
+- clicking the trigger opens a compact popover above the footer control
+- the popover stays visually inside the editor and does not expand into a side panel
+- `Zoom In` updates the canvas transform and footer percentage
+- `Zoom Out` updates the canvas transform and footer percentage
+- `Fit to Screen` restores the fitted view for the current editor viewport
+- instructional rows render with the intended non-interactive styling
+- the popover styling matches the side-panel surface language without adopting side-panel dimensions
+
+## Recommended Rollout
+
+Implement in this order:
+1. Replace the footer pin slot with a zoom trigger and popover shell
+2. Wire the zoom actions to existing transform state and fit behavior
+3. Add compact popover styling that borrows from the side-panel surface language
+4. Verify placement, behavior, and footer percentage syncing

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -1097,6 +1097,134 @@ pub fn install_editor_css() {
                 border-color: rgba(255, 255, 255, 0.2);
             }
 
+            button.editor-footer-zoom-button {
+                min-height: 30px;
+                padding: 0 10px;
+                border-radius: 8px;
+                border: 1px solid transparent;
+                background: transparent;
+                color: rgba(245, 245, 247, 0.92);
+                box-shadow: none;
+            }
+
+            button.editor-footer-zoom-button:hover {
+                background: rgba(255, 255, 255, 0.06);
+                border-color: rgba(255, 255, 255, 0.1);
+                color: #ffffff;
+            }
+
+            .editor-footer-zoom-label {
+                color: inherit;
+                font-size: 13px;
+                font-weight: 700;
+            }
+
+            .editor-footer-zoom-popup {
+                padding: 0;
+                background: rgba(20, 20, 20, 0.94);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: 12px;
+                min-width: 220px;
+                box-shadow: none;
+            }
+
+            .editor-footer-zoom-header {
+                padding: 12px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+            }
+
+            button.editor-footer-zoom-header-btn {
+                min-width: 28px;
+                min-height: 28px;
+                padding: 0;
+                border-radius: 6px;
+                background: rgba(255, 255, 255, 0.05);
+                border: none;
+                color: #ffffff;
+                transition: all 120ms ease;
+            }
+
+            button.editor-footer-zoom-header-btn:hover {
+                background: rgba(255, 255, 255, 0.1);
+            }
+
+            button.editor-footer-zoom-header-btn.orange-btn {
+                background: #ff9900;
+                color: #ffffff;
+            }
+
+            button.editor-footer-zoom-header-btn.orange-btn:hover {
+                background: #ffaa33;
+            }
+
+            .editor-footer-zoom-header-label {
+                font-weight: 600;
+                font-size: 16px;
+                color: #ffffff;
+            }
+
+            .editor-footer-zoom-list {
+                padding: 8px 0;
+            }
+
+            button.editor-footer-zoom-action-btn {
+                padding: 0;
+                margin: 0 4px;
+                border-radius: 8px;
+                border: none;
+                background: transparent;
+                transition: all 120ms ease;
+            }
+
+            button.editor-footer-zoom-action-btn:hover {
+                background: rgba(255, 255, 255, 0.04);
+            }
+
+            .editor-footer-zoom-row {
+                padding: 6px 12px;
+                min-height: 36px;
+                color: #e0e0e0;
+                font-size: 13px;
+            }
+
+            .editor-footer-zoom-shortcut-box {
+                margin-left: 12px;
+            }
+
+            .editor-footer-zoom-shortcut-part {
+                font-size: 11px;
+                color: #a0a0a0;
+                font-weight: 600;
+                background: rgba(255, 255, 255, 0.06);
+                border: 1px solid rgba(255, 255, 255, 0.08);
+                border-radius: 4px;
+                padding: 2px 6px;
+                min-width: 20px;
+                text-align: center;
+            }
+
+            .editor-footer-zoom-separator {
+                height: 1px;
+                background: rgba(255, 255, 255, 0.05);
+                margin: 4px 12px;
+            }
+
+            .editor-footer-zoom-mouse-hints {
+                padding: 16px 12px;
+            }
+
+            .editor-footer-zoom-mouse-hint-text {
+                font-size: 11px;
+                color: #808080;
+                line-height: 1.3;
+            }
+
+            .editor-footer-zoom-mouse-drawing {
+                min-width: 60px;
+                min-height: 60px;
+                margin: 0 8px;
+            }
+
             .editor-root.editor-theme-dark,
             .editor-root.editor-theme-light {
                 background-color: #141414;
@@ -2534,6 +2662,33 @@ mod tests {
                 && production_source.contains(".editor-crop-inspector-check {\n                color: #ff9900;")
                 && production_source.contains(".editor-crop-dimensions-row {\n                padding: 10px 12px;"),
             "Crop inspector should use the same restrained inspector surface language as the other side-panel tools",
+        );
+    }
+
+    #[test]
+    fn footer_zoom_popover_reuses_inspector_surface_language_without_sidebar_dimensions() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains(".editor-footer-zoom-popup {\n                padding: 8px;")
+                && production_source.contains("background: rgba(20, 20, 22, 0.96);")
+                && production_source.contains("border: 1px solid rgba(255, 255, 255, 0.08);")
+                && production_source.contains("border-radius: 12px;")
+                && !production_source.contains(".editor-footer-zoom-popup {\n                min-height: 100%;")
+                && !production_source.contains(".editor-footer-zoom-popup {\n                width: 210px;"),
+            "Footer zoom popover should borrow inspector surface styling without becoming a full-height or fixed-width sidebar",
+        );
+    }
+
+    #[test]
+    fn footer_zoom_rows_distinguish_actions_from_instructional_rows() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("button.editor-footer-zoom-action {\n                min-width: 180px;\n                min-height: 32px;")
+                && production_source.contains("button.editor-footer-zoom-action:hover {\n                background: rgba(255, 255, 255, 0.08);")
+                && production_source.contains(".editor-footer-zoom-hint {\n                margin: 2px 2px 0 2px;\n                color: rgba(241, 241, 243, 0.68);"),
+            "Footer zoom styling should keep action rows interactive and hint rows clearly non-interactive",
         );
     }
 

--- a/src/capture/editor/window/canvas.rs
+++ b/src/capture/editor/window/canvas.rs
@@ -28,10 +28,10 @@ pub(super) fn build_canvas_shell(
     eyedropper_loupe_size: i32,
 ) -> CanvasShellParts {
     let drawing_area = DrawingArea::new();
-    drawing_area.set_hexpand(false);
-    drawing_area.set_vexpand(false);
-    drawing_area.set_halign(gtk4::Align::Start);
-    drawing_area.set_valign(gtk4::Align::Start);
+    drawing_area.set_hexpand(true);
+    drawing_area.set_vexpand(true);
+    drawing_area.set_halign(gtk4::Align::Fill);
+    drawing_area.set_valign(gtk4::Align::Fill);
     drawing_area.set_focusable(true);
     drawing_area.set_focus_on_click(true);
     drawing_area.set_content_width(img_width);
@@ -39,12 +39,10 @@ pub(super) fn build_canvas_shell(
     drawing_area.add_css_class("editor-canvas");
 
     let canvas_overlay = Overlay::new();
-    canvas_overlay.set_hexpand(false);
-    canvas_overlay.set_vexpand(false);
-    canvas_overlay.set_halign(gtk4::Align::Start);
-    canvas_overlay.set_valign(gtk4::Align::Start);
-    // Set a small size request to prevent natural size propagation
-    canvas_overlay.set_size_request(1, 1);
+    canvas_overlay.set_hexpand(true);
+    canvas_overlay.set_vexpand(true);
+    canvas_overlay.set_halign(gtk4::Align::Fill);
+    canvas_overlay.set_valign(gtk4::Align::Fill);
     canvas_overlay.set_child(Some(&drawing_area));
 
     let canvas_scroller = ScrolledWindow::new();
@@ -52,11 +50,7 @@ pub(super) fn build_canvas_shell(
     canvas_scroller.set_vexpand(true);
     canvas_scroller.set_has_frame(false);
     canvas_scroller.set_policy(gtk4::PolicyType::Automatic, gtk4::PolicyType::Automatic);
-    canvas_scroller.set_propagate_natural_width(false);
-    canvas_scroller.set_propagate_natural_height(false);
-    // Use a fixed size request for the scroller to prevent it from growing the window.
-    // It will still fill the space due to hexpand/vexpand.
-    canvas_scroller.set_size_request(400, 300);
+    canvas_scroller.set_overlay_scrolling(false);
     canvas_scroller.set_child(Some(&canvas_overlay));
 
     let canvas_eyedropper_ring = DrawingArea::new();

--- a/src/capture/editor/window/canvas.rs
+++ b/src/capture/editor/window/canvas.rs
@@ -28,26 +28,35 @@ pub(super) fn build_canvas_shell(
     eyedropper_loupe_size: i32,
 ) -> CanvasShellParts {
     let drawing_area = DrawingArea::new();
-    drawing_area.set_hexpand(true);
+    drawing_area.set_hexpand(false);
     drawing_area.set_vexpand(false);
+    drawing_area.set_halign(gtk4::Align::Start);
+    drawing_area.set_valign(gtk4::Align::Start);
     drawing_area.set_focusable(true);
     drawing_area.set_focus_on_click(true);
     drawing_area.set_content_width(img_width);
     drawing_area.set_content_height(img_height);
-    drawing_area.set_size_request(img_width, img_height);
     drawing_area.add_css_class("editor-canvas");
 
     let canvas_overlay = Overlay::new();
-    canvas_overlay.set_hexpand(true);
+    canvas_overlay.set_hexpand(false);
     canvas_overlay.set_vexpand(false);
-    canvas_overlay.set_size_request(img_width, img_height);
+    canvas_overlay.set_halign(gtk4::Align::Start);
+    canvas_overlay.set_valign(gtk4::Align::Start);
+    // Set a small size request to prevent natural size propagation
+    canvas_overlay.set_size_request(1, 1);
     canvas_overlay.set_child(Some(&drawing_area));
 
     let canvas_scroller = ScrolledWindow::new();
     canvas_scroller.set_hexpand(true);
     canvas_scroller.set_vexpand(true);
     canvas_scroller.set_has_frame(false);
-    canvas_scroller.set_policy(gtk4::PolicyType::Never, gtk4::PolicyType::Automatic);
+    canvas_scroller.set_policy(gtk4::PolicyType::Automatic, gtk4::PolicyType::Automatic);
+    canvas_scroller.set_propagate_natural_width(false);
+    canvas_scroller.set_propagate_natural_height(false);
+    // Use a fixed size request for the scroller to prevent it from growing the window.
+    // It will still fill the space due to hexpand/vexpand.
+    canvas_scroller.set_size_request(400, 300);
     canvas_scroller.set_child(Some(&canvas_overlay));
 
     let canvas_eyedropper_ring = DrawingArea::new();

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -1,16 +1,14 @@
 use gtk4::{
     gdk, glib, prelude::*, Application, ApplicationWindow, Box as GtkBox, Button, CheckButton,
-    DrawingArea, EventControllerKey, EventControllerMotion, GestureClick, GestureDrag, Image,
-    Label, Popover, Scale,
+    DrawingArea, EventControllerKey, EventControllerMotion, EventControllerScroll,
+    EventControllerScrollFlags, GestureClick, GestureDrag, Image, Label, Overlay, Popover, Scale,
+    ScrolledWindow,
 };
 use image::RgbaImage;
 use std::cell::{Cell, RefCell};
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc, Mutex,
-};
+use std::sync::{Arc, Mutex};
 
 use super::super::{
     color::{palette_index_for_color, DRAG_REDRAW_INTERVAL_US, DRAW_COLORS},
@@ -33,6 +31,9 @@ const RESIZE_HANDLE_DRAG_SIZE: f64 = 18.0;
 const ARROW_CLICK_NOOP_DISTANCE: f64 = 3.0;
 const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
 const TEXT_FONT_FAMILIES: [&str; 5] = ["Sans", "Serif", "Monospace", "Fantasy", "Cursive"];
+const MIN_ZOOM_LEVEL: f64 = 0.25;
+const MAX_ZOOM_LEVEL: f64 = 6.0;
+const ZOOM_STEP: f64 = 1.1;
 use super::super::pen_weight::{HighlighterMode, PenWeight};
 use super::{
     canvas::{
@@ -42,6 +43,10 @@ use super::{
     cursor::{cursor_name_for_view_point, set_window_cursor_name},
     icon_names,
 };
+
+fn clamp_zoom_level(value: f64) -> f64 {
+    value.clamp(MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL)
+}
 
 fn sync_arrow_option_selection(list: &GtkBox, selected_index: usize) {
     let mut child_opt = list.first_child();
@@ -159,10 +164,19 @@ pub(super) struct EventContext {
     pub traffic_close: Button,
     pub traffic_minimize: Button,
     pub traffic_zoom: Button,
-    pub pin_btn: Button,
-    pub pin_icon: Image,
-    pub initial_pin_state: bool,
-    pub set_window_pinned: Rc<dyn Fn(bool)>,
+    pub canvas_overlay: Overlay,
+    pub canvas_scroller: ScrolledWindow,
+    pub zoom_button: Button,
+    pub zoom_label: Label,
+    pub zoom_header_label: Label,
+    pub zoom_popup: GtkBox,
+    pub zoom_minus_btn: Button,
+    pub zoom_plus_btn: Button,
+    pub zoom_in_btn: Button,
+    pub zoom_out_btn: Button,
+    pub fit_to_screen_btn: Button,
+    pub zoom_to_selection_btn: Button,
+    pub zoom_level: Rc<Cell<f64>>,
     pub drag_btn: Button,
     pub copy_btn: Button,
     pub upload_btn: Button,
@@ -241,10 +255,19 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         traffic_close,
         traffic_minimize,
         traffic_zoom,
-        pin_btn,
-        pin_icon,
-        initial_pin_state,
-        set_window_pinned,
+        canvas_overlay: _canvas_overlay,
+        canvas_scroller,
+        zoom_button,
+        zoom_label: _zoom_label,
+        zoom_header_label,
+        zoom_popup,
+        zoom_minus_btn,
+        zoom_plus_btn,
+        zoom_in_btn,
+        zoom_out_btn,
+        fit_to_screen_btn,
+        zoom_to_selection_btn,
+        zoom_level,
         drag_btn,
         copy_btn,
         upload_btn,
@@ -528,25 +551,155 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     });
     drag_btn.add_controller(drag_window_gesture);
 
-    let pin_state = Arc::new(AtomicBool::new(initial_pin_state));
-    pin_icon.set_icon_name(Some(if initial_pin_state {
-        icon_names::PIN
-    } else {
-        icon_names::VIEW_PIN
-    }));
-    let pin_state_btn = pin_state.clone();
-    let pin_icon_btn = pin_icon.clone();
-    let set_window_pinned_btn = set_window_pinned.clone();
-    pin_btn.connect_clicked(move |_| {
-        let now_pinned = !pin_state_btn.load(Ordering::Relaxed);
-        pin_state_btn.store(now_pinned, Ordering::Relaxed);
-        pin_icon_btn.set_icon_name(Some(if now_pinned {
-            icon_names::PIN
-        } else {
-            icon_names::VIEW_PIN
-        }));
-        set_window_pinned_btn(now_pinned);
+    let apply_zoom_change: Rc<dyn Fn(f64)> = Rc::new({
+        let zoom_level = zoom_level.clone();
+        let update_canvas_content_size = update_canvas_content_size.clone();
+        let drawing_area = drawing_area.clone();
+        move |next_zoom| {
+            zoom_level.set(clamp_zoom_level(next_zoom));
+            update_canvas_content_size();
+            drawing_area.queue_draw();
+        }
     });
+
+    let zoom_popup_btn = zoom_popup.clone();
+    zoom_button.connect_clicked(move |_| {
+        zoom_popup_btn.set_visible(!zoom_popup_btn.is_visible());
+    });
+
+    let apply_zoom_change_btn = apply_zoom_change.clone();
+    let zoom_level_in = zoom_level.clone();
+    let zoom_popup_in = zoom_popup.clone();
+    zoom_in_btn.connect_clicked(move |b| {
+        apply_zoom_change_btn(zoom_level_in.get() * ZOOM_STEP);
+        let _ = b;
+        zoom_popup_in.set_visible(false);
+    });
+
+    let apply_zoom_change_btn = apply_zoom_change.clone();
+    let zoom_level_out = zoom_level.clone();
+    let zoom_popup_out = zoom_popup.clone();
+    zoom_out_btn.connect_clicked(move |b| {
+        apply_zoom_change_btn(zoom_level_out.get() / ZOOM_STEP);
+        let _ = b;
+        zoom_popup_out.set_visible(false);
+    });
+
+    let apply_zoom_change_btn = apply_zoom_change.clone();
+    let zoom_popup_fit = zoom_popup.clone();
+    fit_to_screen_btn.connect_clicked(move |b| {
+        apply_zoom_change_btn(1.0);
+        let _ = b;
+        zoom_popup_fit.set_visible(false);
+    });
+
+    let apply_zoom_change_btn = apply_zoom_change.clone();
+    let zoom_level_minus = zoom_level.clone();
+    zoom_minus_btn.connect_clicked(move |_| {
+        apply_zoom_change_btn(zoom_level_minus.get() / ZOOM_STEP);
+    });
+
+    let apply_zoom_change_btn = apply_zoom_change.clone();
+    let zoom_level_plus = zoom_level.clone();
+    zoom_plus_btn.connect_clicked(move |_| {
+        apply_zoom_change_btn(zoom_level_plus.get() * ZOOM_STEP);
+    });
+
+    // Make the header label clickable to reset zoom to 100%
+    let apply_zoom_change_label = apply_zoom_change.clone();
+    let label_click = GestureClick::new();
+    label_click.connect_pressed(move |_, _, _, _| {
+        apply_zoom_change_label(1.0);
+    });
+    zoom_header_label.add_controller(label_click);
+
+    let zoom_popup_sel = zoom_popup.clone();
+    let state_zoom_sel = state.clone();
+    let transform_zoom_sel = transform.clone();
+    let drawing_area_zoom_sel = drawing_area.clone();
+    let zoom_level_zoom_sel = zoom_level.clone();
+    let canvas_scroller_zoom_sel = canvas_scroller.clone();
+    zoom_to_selection_btn.connect_clicked(move |b| {
+        let selection_rect = {
+            let st = state_zoom_sel.lock().unwrap();
+            if let Some(crop_rect) = st.draft_crop_rect().or(st.crop_selection) {
+                Some(crop_rect)
+            } else if let Some(action_idx) = st.selected_action_index {
+                if let Some(action) = st.actions.get(action_idx) {
+                    super::super::selection::action_bounds_with_padding(action, 0.0)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
+        if let Some(rect) = selection_rect {
+            let scroller_w = canvas_scroller_zoom_sel.allocated_width() as f64;
+            let scroller_h = canvas_scroller_zoom_sel.allocated_height() as f64;
+            let padding = super::canvas::CANVAS_PADDING as f64 * 2.0 + 40.0;
+            let available_w = (scroller_w - padding).max(100.0);
+            let available_h = (scroller_h - padding).max(100.0);
+
+            let scale_x = available_w / rect.width.max(1) as f64;
+            let scale_y = available_h / rect.height.max(1) as f64;
+            let new_scale = scale_x.min(scale_y).clamp(0.25, 6.0);
+
+            // Update zoom level and transform
+            zoom_level_zoom_sel.set(new_scale);
+            {
+                let mut t = transform_zoom_sel.lock().unwrap();
+                t.scale = new_scale;
+                // Center the rect in the view
+                t.offset_x = (scroller_w - rect.width as f64 * new_scale) / 2.0 - rect.x as f64 * new_scale;
+                t.offset_y = (scroller_h - rect.height as f64 * new_scale) / 2.0 - rect.y as f64 * new_scale;
+            }
+
+            drawing_area_zoom_sel.queue_draw();
+        }
+
+        if let Some(popover) = b.ancestor(Popover::static_type()) {
+            popover.downcast::<Popover>().unwrap().popdown();
+        }
+        zoom_popup_sel.set_visible(false);
+    });
+
+    let scroll_controller = EventControllerScroll::new(
+        EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::DISCRETE,
+    );
+    let apply_zoom_change_scroll = apply_zoom_change.clone();
+    let zoom_level_scroll = zoom_level.clone();
+    scroll_controller.connect_scroll(move |_, _dx, dy| {
+        if dy < 0.0 {
+            apply_zoom_change_scroll(zoom_level_scroll.get() * ZOOM_STEP);
+        } else if dy > 0.0 {
+            apply_zoom_change_scroll(zoom_level_scroll.get() / ZOOM_STEP);
+        }
+        glib::Propagation::Stop
+    });
+    drawing_area.add_controller(scroll_controller);
+
+    let pan_origin = Rc::new(Cell::new((0.0, 0.0)));
+    let pan_drag = GestureDrag::new();
+    pan_drag.set_button(3);
+    let pan_origin_begin = pan_origin.clone();
+    let canvas_scroller_begin = canvas_scroller.clone();
+    pan_drag.connect_drag_begin(move |_, _x, _y| {
+        let hadj = canvas_scroller_begin.hadjustment();
+        let vadj = canvas_scroller_begin.vadjustment();
+        pan_origin_begin.set((hadj.value(), vadj.value()));
+    });
+    let pan_origin_update = pan_origin.clone();
+    let canvas_scroller_update = canvas_scroller.clone();
+    pan_drag.connect_drag_update(move |_, offset_x, offset_y| {
+        let hadj = canvas_scroller_update.hadjustment();
+        let vadj = canvas_scroller_update.vadjustment();
+        let (start_x, start_y) = pan_origin_update.get();
+        hadj.set_value((start_x - offset_x).clamp(hadj.lower(), hadj.upper() - hadj.page_size()));
+        vadj.set_value((start_y - offset_y).clamp(vadj.lower(), vadj.upper() - vadj.page_size()));
+    });
+    drawing_area.add_controller(pan_drag);
 
     let path_copy = path.clone();
     copy_btn.connect_clicked(move |_| {
@@ -2071,6 +2224,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     drawing_area.add_controller(key_controller);
 
     let click = GestureClick::new();
+    click.set_button(1);
     let window_click = window.clone();
     let state_click = state.clone();
     let transform_click = transform.clone();
@@ -2859,6 +3013,11 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let canvas_eyedropper_ring_keys = canvas_eyedropper_ring.clone();
     let window_keys = window.downgrade();
     let app_keys = app.downgrade();
+
+    let zoom_level_keys = zoom_level.clone();
+    let update_canvas_content_size_keys = update_canvas_content_size.clone();
+    let zoom_popup_keys = zoom_popup.clone();
+
     key_controller.connect_key_pressed(move |_, key, _, modifiers| {
         if key == gdk::Key::Escape && eyedropper_mode_keys.get() {
             eyedropper_mode_keys.set(false);
@@ -2950,6 +3109,38 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
             return glib::Propagation::Stop;
         }
 
+        if ctrl {
+            let mut handled = false;
+            match key {
+                gdk::Key::plus | gdk::Key::equal | gdk::Key::KP_Add => {
+                    zoom_level_keys.set(clamp_zoom_level(zoom_level_keys.get() * ZOOM_STEP));
+                    handled = true;
+                }
+                gdk::Key::minus | gdk::Key::underscore | gdk::Key::KP_Subtract => {
+                    zoom_level_keys.set(clamp_zoom_level(zoom_level_keys.get() / ZOOM_STEP));
+                    handled = true;
+                }
+                gdk::Key::_0 | gdk::Key::KP_0 => {
+                    zoom_level_keys.set(1.0);
+                    handled = true;
+                }
+                gdk::Key::_2 | gdk::Key::KP_2 => {
+                    zoom_level_keys.set(clamp_zoom_level(1.5));
+                    handled = true;
+                }
+                _ => {}
+            }
+
+            if handled {
+                update_canvas_content_size_keys();
+                if let Some(area) = drawing_area_keys.upgrade() {
+                    area.queue_draw();
+                }
+                zoom_popup_keys.set_visible(false);
+                return glib::Propagation::Stop;
+            }
+        }
+
         if !ctrl {
             if let Some((tool, active_button)) = pressed.and_then(tool_shortcut_target) {
                 set_active_tool_button(&tool_buttons_keys, active_button);
@@ -3006,4 +3197,42 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
         }
         glib::Propagation::Proceed
     });
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn event_context_uses_zoom_footer_fields_instead_of_pin_state() {
+        let source = include_str!("events.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("pub zoom_button: Button,")
+                && production_source.contains("pub zoom_label: Label,")
+                && production_source.contains("pub zoom_popup: GtkBox,")
+                && production_source.contains("pub zoom_in_btn: Button,")
+                && production_source.contains("pub zoom_out_btn: Button,")
+                && production_source.contains("pub fit_to_screen_btn: Button,")
+                && !production_source.contains("pub pin_btn: Button,")
+                && !production_source.contains("pub initial_pin_state: bool,"),
+            "EventContext should be updated to drive footer zoom controls instead of pinning state",
+        );
+    }
+
+    #[test]
+    fn footer_zoom_actions_update_transform_and_label() {
+        let source = include_str!("events.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("zoom_button.connect_clicked(move |_| {")
+                && production_source.contains("zoom_popup_btn.set_visible(!zoom_popup_btn.is_visible());")
+                && production_source.contains("zoom_in_btn.connect_clicked(move |b| {")
+                && production_source.contains("zoom_out_btn.connect_clicked(move |b| {")
+                && production_source.contains("fit_to_screen_btn.connect_clicked(move |b| {")
+                && production_source.contains("zoom_popup_in.set_visible(false);")
+                && production_source.contains("update_canvas_content_size();")
+                && production_source.contains("drawing_area.queue_draw();")
+                && production_source.contains("scroll_controller.connect_scroll(move |_, _dx, dy| {"),
+            "Footer zoom actions should open the popover, update the zoom state, refresh canvas layout, and support wheel zoom",
+        );
+    }
 }

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -652,8 +652,10 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
                 let mut t = transform_zoom_sel.lock().unwrap();
                 t.scale = new_scale;
                 // Center the rect in the view
-                t.offset_x = (scroller_w - rect.width as f64 * new_scale) / 2.0 - rect.x as f64 * new_scale;
-                t.offset_y = (scroller_h - rect.height as f64 * new_scale) / 2.0 - rect.y as f64 * new_scale;
+                t.offset_x =
+                    (scroller_w - rect.width as f64 * new_scale) / 2.0 - rect.x as f64 * new_scale;
+                t.offset_y =
+                    (scroller_h - rect.height as f64 * new_scale) / 2.0 - rect.y as f64 * new_scale;
             }
 
             drawing_area_zoom_sel.queue_draw();

--- a/src/capture/editor/window/footer.rs
+++ b/src/capture/editor/window/footer.rs
@@ -75,8 +75,20 @@ fn build_mouse_hints() -> GtkBox {
         cr.set_source_rgba(1.0, 1.0, 1.0, 0.1);
         cr.set_line_width(1.0);
         cr.new_sub_path();
-        cr.arc(mouse_x + radius, mouse_y + radius, radius, 180.0 * std::f64::consts::PI / 180.0, 270.0 * std::f64::consts::PI / 180.0);
-        cr.arc(mouse_x + mouse_w - radius, mouse_y + radius, radius, 270.0 * std::f64::consts::PI / 180.0, 360.0 * std::f64::consts::PI / 180.0);
+        cr.arc(
+            mouse_x + radius,
+            mouse_y + radius,
+            radius,
+            180.0 * std::f64::consts::PI / 180.0,
+            270.0 * std::f64::consts::PI / 180.0,
+        );
+        cr.arc(
+            mouse_x + mouse_w - radius,
+            mouse_y + radius,
+            radius,
+            270.0 * std::f64::consts::PI / 180.0,
+            360.0 * std::f64::consts::PI / 180.0,
+        );
         cr.line_to(mouse_x + mouse_w, mouse_y + mouse_h);
         cr.line_to(mouse_x, mouse_y + mouse_h);
         cr.close_path();
@@ -94,8 +106,20 @@ fn build_mouse_hints() -> GtkBox {
         let wheel_y = mouse_y + 8.0;
         cr.set_source_rgba(0.0, 0.5, 1.0, 0.8);
         cr.new_sub_path();
-        cr.arc(wheel_x + wheel_w / 2.0, wheel_y + wheel_w / 2.0, wheel_w / 2.0, 180.0 * std::f64::consts::PI / 180.0, 360.0 * std::f64::consts::PI / 180.0);
-        cr.arc(wheel_x + wheel_w / 2.0, wheel_y + wheel_h - wheel_w / 2.0, wheel_w / 2.0, 0.0, 180.0 * std::f64::consts::PI / 180.0);
+        cr.arc(
+            wheel_x + wheel_w / 2.0,
+            wheel_y + wheel_w / 2.0,
+            wheel_w / 2.0,
+            180.0 * std::f64::consts::PI / 180.0,
+            360.0 * std::f64::consts::PI / 180.0,
+        );
+        cr.arc(
+            wheel_x + wheel_w / 2.0,
+            wheel_y + wheel_h - wheel_w / 2.0,
+            wheel_w / 2.0,
+            0.0,
+            180.0 * std::f64::consts::PI / 180.0,
+        );
         cr.close_path();
         let _ = cr.fill();
 
@@ -105,12 +129,26 @@ fn build_mouse_hints() -> GtkBox {
 
         // To scroll wheel
         cr.move_to(mouse_x - 5.0, wheel_y + wheel_h / 2.0);
-        cr.curve_to(mouse_x - 15.0, wheel_y + wheel_h / 2.0, wheel_x - 5.0, wheel_y + wheel_h / 2.0, wheel_x - 2.0, wheel_y + wheel_h / 2.0);
+        cr.curve_to(
+            mouse_x - 15.0,
+            wheel_y + wheel_h / 2.0,
+            wheel_x - 5.0,
+            wheel_y + wheel_h / 2.0,
+            wheel_x - 2.0,
+            wheel_y + wheel_h / 2.0,
+        );
         let _ = cr.stroke();
 
         // To right button
         cr.move_to(w - (mouse_x - 5.0), wheel_y + wheel_h / 2.0);
-        cr.curve_to(w - (mouse_x - 15.0), wheel_y + wheel_h / 2.0, wheel_x + wheel_w + 5.0, wheel_y + wheel_h / 2.0, wheel_x + wheel_w + 2.0, wheel_y + wheel_h / 2.0);
+        cr.curve_to(
+            w - (mouse_x - 15.0),
+            wheel_y + wheel_h / 2.0,
+            wheel_x + wheel_w + 5.0,
+            wheel_y + wheel_h / 2.0,
+            wheel_x + wheel_w + 2.0,
+            wheel_y + wheel_h / 2.0,
+        );
         let _ = cr.stroke();
     });
 

--- a/src/capture/editor/window/footer.rs
+++ b/src/capture/editor/window/footer.rs
@@ -1,22 +1,196 @@
-use gtk4::{prelude::*, Box as GtkBox, Button, Image, Orientation};
+use gtk4::{prelude::*, Box as GtkBox, Button, Label, Orientation};
 
 use super::super::ui_support::footer_icon_button;
 
 pub(super) struct FooterParts {
     pub root: GtkBox,
-    pub pin_btn: Button,
-    pub pin_icon: Image,
+    pub zoom_button: Button,
+    pub zoom_label: Label,
+    pub zoom_header_label: Label,
+    pub zoom_popup: GtkBox,
+    pub zoom_minus_btn: Button,
+    pub zoom_plus_btn: Button,
+    pub zoom_in_btn: Button,
+    pub zoom_out_btn: Button,
+    pub fit_to_screen_btn: Button,
+    pub zoom_to_selection_btn: Button,
     pub drag_btn: Button,
     pub copy_btn: Button,
     pub upload_btn: Button,
 }
 
-pub(super) fn build_footer(
-    pin_icon_name: &str,
-    copy_icon_name: &str,
-    upload_icon_name: &str,
-) -> FooterParts {
-    let (pin_btn, pin_icon) = footer_icon_button(pin_icon_name, "Pin window");
+fn build_zoom_row(label: &str, shortcut: &str) -> (Button, GtkBox) {
+    let row = GtkBox::new(Orientation::Horizontal, 0);
+    row.add_css_class("editor-footer-zoom-row");
+
+    let label_widget = Label::new(Some(label));
+    label_widget.set_hexpand(true);
+    label_widget.set_xalign(0.0);
+
+    let shortcut_box = GtkBox::new(Orientation::Horizontal, 4);
+    shortcut_box.add_css_class("editor-footer-zoom-shortcut-box");
+
+    for part in shortcut.split(' ') {
+        let part_label = Label::new(Some(part));
+        part_label.add_css_class("editor-footer-zoom-shortcut-part");
+        shortcut_box.append(&part_label);
+    }
+
+    row.append(&label_widget);
+    row.append(&shortcut_box);
+
+    let btn = Button::builder()
+        .has_frame(false)
+        .css_classes(["flat", "editor-footer-zoom-action-btn"])
+        .child(&row)
+        .build();
+
+    (btn, row)
+}
+
+fn build_mouse_hints() -> GtkBox {
+    let container = GtkBox::new(Orientation::Horizontal, 0);
+    container.add_css_class("editor-footer-zoom-mouse-hints");
+    container.set_halign(gtk4::Align::Center);
+
+    let left_text = Label::new(Some("Zoom with\nthe scroll\nwheel"));
+    left_text.set_justify(gtk4::Justification::Right);
+    left_text.add_css_class("editor-footer-zoom-mouse-hint-text");
+
+    let drawing = gtk4::DrawingArea::new();
+    drawing.add_css_class("editor-footer-zoom-mouse-drawing");
+    drawing.set_content_width(60);
+    drawing.set_content_height(60);
+    drawing.set_draw_func(move |_, cr, width, height| {
+        let w = f64::from(width);
+        let h = f64::from(height);
+
+        // Draw mouse body (simple rounded rect)
+        let mouse_w = 24.0;
+        let mouse_h = 40.0;
+        let mouse_x = (w - mouse_w) / 2.0;
+        let mouse_y = h - mouse_h - 5.0;
+        let radius = 10.0;
+
+        cr.set_source_rgba(1.0, 1.0, 1.0, 0.1);
+        cr.set_line_width(1.0);
+        cr.new_sub_path();
+        cr.arc(mouse_x + radius, mouse_y + radius, radius, 180.0 * std::f64::consts::PI / 180.0, 270.0 * std::f64::consts::PI / 180.0);
+        cr.arc(mouse_x + mouse_w - radius, mouse_y + radius, radius, 270.0 * std::f64::consts::PI / 180.0, 360.0 * std::f64::consts::PI / 180.0);
+        cr.line_to(mouse_x + mouse_w, mouse_y + mouse_h);
+        cr.line_to(mouse_x, mouse_y + mouse_h);
+        cr.close_path();
+        let _ = cr.stroke();
+
+        // Draw middle line for buttons
+        cr.move_to(mouse_x + mouse_w / 2.0, mouse_y);
+        cr.line_to(mouse_x + mouse_w / 2.0, mouse_y + 15.0);
+        let _ = cr.stroke();
+
+        // Draw scroll wheel (highlighted blue)
+        let wheel_w = 4.0;
+        let wheel_h = 10.0;
+        let wheel_x = (w - wheel_w) / 2.0;
+        let wheel_y = mouse_y + 8.0;
+        cr.set_source_rgba(0.0, 0.5, 1.0, 0.8);
+        cr.new_sub_path();
+        cr.arc(wheel_x + wheel_w / 2.0, wheel_y + wheel_w / 2.0, wheel_w / 2.0, 180.0 * std::f64::consts::PI / 180.0, 360.0 * std::f64::consts::PI / 180.0);
+        cr.arc(wheel_x + wheel_w / 2.0, wheel_y + wheel_h - wheel_w / 2.0, wheel_w / 2.0, 0.0, 180.0 * std::f64::consts::PI / 180.0);
+        cr.close_path();
+        let _ = cr.fill();
+
+        // Draw lines pointing to hints
+        cr.set_source_rgba(0.0, 0.5, 1.0, 0.4);
+        cr.set_line_width(0.8);
+
+        // To scroll wheel
+        cr.move_to(mouse_x - 5.0, wheel_y + wheel_h / 2.0);
+        cr.curve_to(mouse_x - 15.0, wheel_y + wheel_h / 2.0, wheel_x - 5.0, wheel_y + wheel_h / 2.0, wheel_x - 2.0, wheel_y + wheel_h / 2.0);
+        let _ = cr.stroke();
+
+        // To right button
+        cr.move_to(w - (mouse_x - 5.0), wheel_y + wheel_h / 2.0);
+        cr.curve_to(w - (mouse_x - 15.0), wheel_y + wheel_h / 2.0, wheel_x + wheel_w + 5.0, wheel_y + wheel_h / 2.0, wheel_x + wheel_w + 2.0, wheel_y + wheel_h / 2.0);
+        let _ = cr.stroke();
+    });
+
+    let right_text = Label::new(Some("Pan with\nthe right\nbutton"));
+    right_text.set_justify(gtk4::Justification::Left);
+    right_text.add_css_class("editor-footer-zoom-mouse-hint-text");
+
+    container.append(&left_text);
+    container.append(&drawing);
+    container.append(&right_text);
+    container
+}
+
+pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> FooterParts {
+    let zoom_button = Button::new();
+    zoom_button.set_has_frame(false);
+    zoom_button.set_tooltip_text(Some("Zoom controls"));
+    zoom_button.add_css_class("editor-footer-zoom-button");
+
+    let zoom_label = Label::new(Some("100%"));
+    zoom_label.add_css_class("editor-footer-zoom-label");
+    zoom_button.set_child(Some(&zoom_label));
+
+    let zoom_popup = GtkBox::new(Orientation::Vertical, 0);
+    zoom_popup.add_css_class("editor-footer-zoom-popup");
+    zoom_popup.set_halign(gtk4::Align::Start);
+    zoom_popup.set_valign(gtk4::Align::End);
+    zoom_popup.set_margin_start(16);
+    zoom_popup.set_margin_bottom(16);
+    zoom_popup.set_visible(false);
+
+    // Header
+    let zoom_header = GtkBox::new(Orientation::Horizontal, 8);
+    zoom_header.add_css_class("editor-footer-zoom-header");
+
+    let zoom_minus_btn = Button::with_label("-");
+    zoom_minus_btn.add_css_class("editor-footer-zoom-header-btn");
+    zoom_minus_btn.add_css_class("flat");
+
+    let zoom_header_label = Label::new(Some("100%"));
+    zoom_header_label.set_hexpand(true);
+    zoom_header_label.add_css_class("editor-footer-zoom-header-label");
+
+    let zoom_plus_btn = Button::with_label("+");
+    zoom_plus_btn.add_css_class("editor-footer-zoom-header-btn");
+    zoom_plus_btn.add_css_class("orange-btn");
+    zoom_plus_btn.add_css_class("flat");
+
+    zoom_header.append(&zoom_minus_btn);
+    zoom_header.append(&zoom_header_label);
+    zoom_header.append(&zoom_plus_btn);
+
+    // List of actions
+    let zoom_list = GtkBox::new(Orientation::Vertical, 0);
+    zoom_list.add_css_class("editor-footer-zoom-list");
+
+    let (zoom_in_btn, _) = build_zoom_row("Zoom In", "Ctrl +");
+    let (zoom_out_btn, _) = build_zoom_row("Zoom Out", "Ctrl -");
+    let (fit_to_screen_btn, _) = build_zoom_row("Fit to Screen", "Ctrl 0");
+    let (zoom_to_selection_btn, _) = build_zoom_row("Zoom to Selection", "Ctrl 2");
+
+    let sep1 = GtkBox::new(Orientation::Horizontal, 0);
+    sep1.add_css_class("editor-footer-zoom-separator");
+
+    let sep2 = GtkBox::new(Orientation::Horizontal, 0);
+    sep2.add_css_class("editor-footer-zoom-separator");
+
+    let mouse_hints = build_mouse_hints();
+
+    zoom_list.append(&zoom_in_btn);
+    zoom_list.append(&zoom_out_btn);
+    zoom_list.append(&fit_to_screen_btn);
+    zoom_list.append(&zoom_to_selection_btn);
+
+    zoom_popup.append(&zoom_header);
+    zoom_popup.append(&sep1);
+    zoom_popup.append(&zoom_list);
+    zoom_popup.append(&sep2);
+    zoom_popup.append(&mouse_hints);
+
     let drag_btn = Button::with_label("Drag me");
     drag_btn.set_has_frame(false);
     drag_btn.set_tooltip_text(Some("Drag to move editor window"));
@@ -31,7 +205,7 @@ pub(super) fn build_footer(
     let footer_left = GtkBox::new(Orientation::Horizontal, 0);
     footer_left.set_hexpand(true);
     footer_left.set_halign(gtk4::Align::Start);
-    footer_left.append(&pin_btn);
+    footer_left.append(&zoom_button);
 
     let footer_center = GtkBox::new(Orientation::Horizontal, 0);
     footer_center.set_hexpand(true);
@@ -50,8 +224,16 @@ pub(super) fn build_footer(
 
     FooterParts {
         root,
-        pin_btn,
-        pin_icon,
+        zoom_button,
+        zoom_label,
+        zoom_header_label,
+        zoom_popup,
+        zoom_minus_btn,
+        zoom_plus_btn,
+        zoom_in_btn,
+        zoom_out_btn,
+        fit_to_screen_btn,
+        zoom_to_selection_btn,
         drag_btn,
         copy_btn,
         upload_btn,

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -2050,11 +2050,15 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
             let scroller_height = canvas_scroller.allocated_height().max(1) as f64;
             let available_width = (scroller_width - (canvas_padding * 2 + 2) as f64).max(1.0);
             let available_height = (scroller_height - (canvas_padding * 2 + 2) as f64).max(1.0);
-            
+
             // Use the minimum of width and height to maintain aspect ratio and prevent asymmetric growth
             let available_size = available_width.min(available_height);
-            let scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64) * zoom_level.get().max(0.1_f64);
-            
+
+            // Layout scale without zoom - used for content size (prevents window from growing on zoom)
+            let layout_scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64);
+            // Rendering scale includes zoom for visual display
+            let scale = layout_scale * zoom_level.get().max(0.1_f64);
+
             let fitted_w = (virtual_w * scale).round().max(1.0) as i32;
             let fitted_h = (virtual_h * scale).round().max(1.0) as i32;
 
@@ -2128,9 +2132,10 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                 let virtual_h = img_h as f64;
                 let available_w = (width as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
                 let available_h = (height as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
-                
+
                 let available_size = available_w.min(available_h);
-                let scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64) * zoom_level_tick.get().max(0.1_f64);
+                let layout_scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64);
+                let _scale = layout_scale * zoom_level_tick.get().max(0.1_f64);
 
                 let (ol, ot, or_, ob) = if has_background {
                     (0.0, 0.0, 0.0, 0.0)
@@ -2139,7 +2144,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                         crop_rect,
                         img_w as f64,
                         img_h as f64,
-                        scale,
+                        layout_scale,
                         crop_mode_active,
                     )
                 };

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -422,6 +422,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         img_width as f64,
         img_height as f64,
     )));
+    let zoom_level = Rc::new(Cell::new(1.0_f64));
 
     let (default_width, default_height) =
         recommended_window_size_with_extra_width(img_width as i32, img_height as i32, 280);
@@ -944,13 +945,18 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         number_size_list.append(&btn);
     }
 
-    let footer_parts = footer::build_footer(
-        icon_names::VIEW_PIN,
-        icon_names::COPY_REGULAR,
-        icon_names::CLOUD_ARROW_UP_REGULAR,
-    );
-    let pin_btn = footer_parts.pin_btn;
-    let pin_icon = footer_parts.pin_icon;
+    let footer_parts =
+        footer::build_footer(icon_names::COPY_REGULAR, icon_names::CLOUD_ARROW_UP_REGULAR);
+    let zoom_button = footer_parts.zoom_button;
+    let zoom_label = footer_parts.zoom_label;
+    let zoom_header_label = footer_parts.zoom_header_label;
+    let zoom_popup = footer_parts.zoom_popup;
+    let zoom_minus_btn = footer_parts.zoom_minus_btn;
+    let zoom_plus_btn = footer_parts.zoom_plus_btn;
+    let zoom_in_btn = footer_parts.zoom_in_btn;
+    let zoom_out_btn = footer_parts.zoom_out_btn;
+    let fit_to_screen_btn = footer_parts.fit_to_screen_btn;
+    let zoom_to_selection_btn = footer_parts.zoom_to_selection_btn;
     let drag_btn = footer_parts.drag_btn;
     let copy_btn = footer_parts.copy_btn;
     let upload_btn = footer_parts.upload_btn;
@@ -958,12 +964,6 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     let tracked_window_id = next_tracked_window_id("annotate-editor");
     let window_title = "Screenshot Editor";
     let window_namespace = "apexshot-annotate-editor";
-
-    pin_icon.set_icon_name(Some(if annotate_config.always_on_top {
-        icon_names::PIN
-    } else {
-        icon_names::VIEW_PIN
-    }));
 
     let canvas::CanvasShellParts {
         root: canvas,
@@ -977,6 +977,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         &GtkBox::new(Orientation::Vertical, 0), // Placeholder, will be replaced
         canvas::EYEDROPPER_LOUPE_SIZE,
     );
+    canvas_overlay.add_overlay(&zoom_popup);
 
     // Background style cache
     let cached_background_surface =
@@ -1993,9 +1994,13 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let update_canvas_content_size: Rc<dyn Fn()> = Rc::new({
         let state = state.clone();
+        let zoom_level = zoom_level.clone();
+        let zoom_label = zoom_label.clone();
+        let zoom_header_label = zoom_header_label.clone();
         let drawing_area = drawing_area.clone();
-        let canvas_overlay = canvas_overlay.clone();
+        let _canvas_overlay = canvas_overlay.clone();
         let canvas_scroller = canvas_scroller.clone();
+        let _window = window.downgrade();
         let canvas_padding = canvas_padding;
         move || {
             let (
@@ -2042,8 +2047,14 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
             }
 
             let scroller_width = canvas_scroller.allocated_width().max(1) as f64;
+            let scroller_height = canvas_scroller.allocated_height().max(1) as f64;
             let available_width = (scroller_width - (canvas_padding * 2 + 2) as f64).max(1.0);
-            let scale = (available_width / virtual_w).min(1.0);
+            let available_height = (scroller_height - (canvas_padding * 2 + 2) as f64).max(1.0);
+            
+            // Use the minimum of width and height to maintain aspect ratio and prevent asymmetric growth
+            let available_size = available_width.min(available_height);
+            let scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64) * zoom_level.get().max(0.1_f64);
+            
             let fitted_w = (virtual_w * scale).round().max(1.0) as i32;
             let fitted_h = (virtual_h * scale).round().max(1.0) as i32;
 
@@ -2070,8 +2081,9 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
             drawing_area.set_content_width(canvas_w);
             drawing_area.set_content_height(canvas_h);
-            drawing_area.set_size_request(canvas_w, canvas_h);
-            canvas_overlay.set_size_request(canvas_w, canvas_h);
+            let percent_str = format!("{}%", (scale * 100.0).round().max(1.0) as i32);
+            zoom_label.set_label(&percent_str);
+            zoom_header_label.set_label(&percent_str);
         }
     });
     update_canvas_content_size();
@@ -2079,6 +2091,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
     {
         let update_canvas_content_size_tick = update_canvas_content_size.clone();
         let state_canvas_tick = state.clone();
+        let zoom_level_tick = zoom_level.clone();
         // Signature tracks the quantities that actually change the *visible* canvas size.
         // Crucially, raw crop-rect coordinates are NOT included here.  Instead we compute
         // the capped overflow bucket that crop_canvas_overflow() would return and store
@@ -2086,6 +2099,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         // constant throughout an outside-image drag gesture — no relayout churn occurs.
         let last_canvas_signature = Rc::new(Cell::new((
             0_i32, // scroller width
+            0_i32, // scroller height
             0_i32, // image width
             0_i32, // image height
             0_i32, // overflow left (px, capped)
@@ -2093,10 +2107,12 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
             0_i32, // overflow right (px, capped)
             0_i32, // overflow bottom (px, capped)
             false, // crop mode active
+            0_i32, // zoom percentage
         )));
         let last_canvas_signature_tick = last_canvas_signature.clone();
         canvas_scroller.add_tick_callback(move |scroller, _| {
             let width = scroller.allocated_width();
+            let height = scroller.allocated_height();
             let signature = {
                 let st = state_canvas_tick.lock().unwrap();
                 let img_w = st.working_image.width().max(1) as i32;
@@ -2104,12 +2120,17 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                 let crop_mode_active = st.selected_tool == Tool::Crop;
                 let crop_rect = st.draft_crop_rect().or(st.crop_selection);
                 let has_background = st.background_style != BackgroundStyle::None;
+                let zoom_percentage = (zoom_level_tick.get() * 100.0_f64).round() as i32;
 
                 // Compute the same scale the layout function uses so we get the
                 // same overflow values without duplicating the full layout calculation.
                 let virtual_w = img_w as f64;
+                let virtual_h = img_h as f64;
                 let available_w = (width as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
-                let scale = (available_w / virtual_w.max(1.0)).min(1.0);
+                let available_h = (height as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
+                
+                let available_size = available_w.min(available_h);
+                let scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64) * zoom_level_tick.get().max(0.1_f64);
 
                 let (ol, ot, or_, ob) = if has_background {
                     (0.0, 0.0, 0.0, 0.0)
@@ -2125,6 +2146,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
                 (
                     width,
+                    height,
                     img_w,
                     img_h,
                     ol.round() as i32,
@@ -2132,6 +2154,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
                     or_.round() as i32,
                     ob.round() as i32,
                     crop_mode_active,
+                    zoom_percentage,
                 )
             };
             if width > 0 && signature != last_canvas_signature_tick.get() {
@@ -2270,6 +2293,7 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
 
     let state_draw = state.clone();
     let transform_draw = transform.clone();
+    let zoom_level_draw = zoom_level.clone();
     let undo_btn_draw = undo_btn.clone();
     let redo_btn_draw = redo_btn.clone();
     let delete_selected_btn_draw = delete_selected_btn.clone();
@@ -2411,9 +2435,19 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         let view_height =
             (height as f64 - canvas_padding_draw * 2.0 - overflow_top - overflow_bottom).max(1.0);
 
-        let mut t = ViewTransform::fit(virtual_w, virtual_h, view_width, view_height);
-        t.offset_x += canvas_padding_draw + overflow_left;
-        t.offset_y += canvas_padding_draw + overflow_top;
+        let scale = (view_width / virtual_w)
+            .min(view_height / virtual_h)
+            .min(1.0_f64)
+            * zoom_level_draw.get().max(0.1_f64);
+        let draw_width = virtual_w * scale;
+        let draw_height = virtual_h * scale;
+        let mut t = ViewTransform {
+            scale,
+            offset_x: (view_width - draw_width) / 2.0 + canvas_padding_draw + overflow_left,
+            offset_y: (view_height - draw_height) / 2.0 + canvas_padding_draw + overflow_top,
+            image_width: virtual_w,
+            image_height: virtual_h,
+        };
 
         let canvas_t = t.clone();
 
@@ -3001,22 +3035,19 @@ pub fn setup_editor_window(app: &Application, path: PathBuf) {
         traffic_close: traffic_close.clone(),
         traffic_minimize: traffic_minimize.clone(),
         traffic_zoom: traffic_zoom.clone(),
-        pin_btn: pin_btn.clone(),
-        pin_icon: pin_icon.clone(),
-        initial_pin_state: annotate_config.always_on_top,
-        set_window_pinned: Rc::new({
-            let window = window.clone();
-            let tracked_window_id = tracked_window_id.clone();
-            move |enabled| {
-                set_window_always_on_top(
-                    &window,
-                    &tracked_window_id,
-                    enabled,
-                    window_title,
-                    window_namespace,
-                );
-            }
-        }),
+        canvas_overlay: canvas_overlay.clone(),
+        canvas_scroller: canvas_scroller.clone(),
+        zoom_button: zoom_button.clone(),
+        zoom_label: zoom_label.clone(),
+        zoom_header_label: zoom_header_label.clone(),
+        zoom_popup: zoom_popup.clone(),
+        zoom_minus_btn: zoom_minus_btn.clone(),
+        zoom_plus_btn: zoom_plus_btn.clone(),
+        zoom_in_btn: zoom_in_btn.clone(),
+        zoom_out_btn: zoom_out_btn.clone(),
+        fit_to_screen_btn: fit_to_screen_btn.clone(),
+        zoom_to_selection_btn: zoom_to_selection_btn.clone(),
+        zoom_level: zoom_level.clone(),
         drag_btn: drag_btn.clone(),
         copy_btn: copy_btn.clone(),
         upload_btn: upload_btn.clone(),

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -1037,11 +1037,7 @@ pub(super) fn build_toolbar_tool_updater(
         arrow_style_group.set_visible(is_arrow_tool);
         stroke_size_group.set_visible(false);
 
-        if matches!(tool, Tool::Crop) {
-            canvas_scroller.set_policy(gtk4::PolicyType::Never, gtk4::PolicyType::Automatic);
-        } else {
-            canvas_scroller.set_policy(gtk4::PolicyType::Never, gtk4::PolicyType::Never);
-        }
+        canvas_scroller.set_policy(gtk4::PolicyType::Automatic, gtk4::PolicyType::Automatic);
 
         let primary_surface = match tool {
             Tool::Background => Some(("Background", "background")),


### PR DESCRIPTION
## Summary
Add editor footer zoom controls and complete editor panel/styling improvements.

## Changes

### Footer Zoom Controls
- Replace pin button with zoom controls in footer
- Add zoom popup with +/- buttons, zoom presets (25%-600%)
- Support mouse wheel zoom, keyboard shortcuts (Ctrl++/-/0/2)
- Fit to screen and zoom to selection options

### Zoom Fixes
- Prevent editor window from growing beyond screen when zooming in
- Add proper scrollbars for zoomed canvas
- Fix checkerboard background covering full canvas area

### Sidebar/Inspector Panels (from previous work)
- Add right sidebar annotation panel with visual consistency
- Move pen line and highlighter thickness controls into sidebar
- Add number inspector panel with styling
- Add text inspector panel with fonts
- Add arrow inspector panel with style/thickness
- Add crop inspector panel with aspect ratio/dimensions

## Testing
- Footer zoom popup appears on button click
- Zoom controls work with mouse wheel and keyboard
- Canvas scrollbars appear when zoomed in
- Window size stays bounded when zooming