### PR TITLE
Redesign image editor controls and remove ydotool scroll fallback

### DIFF
--- a/capture-overlay/src/CaptureOverlay_Scroll.cpp
+++ b/capture-overlay/src/CaptureOverlay_Scroll.cpp
@@ -278,19 +278,6 @@ void CaptureOverlay::simulateScrollDown()
         std::fprintf(stderr, "[CaptureOverlay] Auto-scroll: portal step accepted, continuing with local fallback\n");
     }
 
-    QString ydotoolPath;
-    QStringList ydotoolPaths = {"/usr/local/bin/ydotool", "/usr/bin/ydotool", "ydotool"};
-    for (const QString& path : ydotoolPaths) {
-        QProcess testProc;
-        testProc.setProgram(path);
-        testProc.setArguments({"help"});
-        testProc.start();
-        if (testProc.waitForFinished(500) && testProc.exitCode() == 0) {
-            ydotoolPath = path;
-            break;
-        }
-    }
-
     QString wtypePath;
     QStringList wtypePaths = {"/usr/local/bin/wtype", "/usr/bin/wtype", "wtype"};
     for (const QString& candidate : wtypePaths) {
@@ -307,15 +294,6 @@ void CaptureOverlay::simulateScrollDown()
             wtypePath = resolved;
             break;
         }
-    }
-
-    QProcessEnvironment env;
-    env.insert("YDOTOOL_SOCKET", "/tmp/.ydotool_socket");
-
-    const bool canUseYdotool = !ydotoolPath.isEmpty() && QFileInfo("/dev/uinput").isWritable();
-    if (!ydotoolPath.isEmpty() && !canUseYdotool) {
-        std::fprintf(stderr,
-                     "[CaptureOverlay] Auto-scroll: ydotool detected but /dev/uinput is not writable; skipping ydotool path\n");
     }
 
     clearFocus();
@@ -336,23 +314,6 @@ void CaptureOverlay::simulateScrollDown()
     };
 
     if (!wtypePath.isEmpty()) {
-        if (canUseYdotool) {
-            QProcess moveProc;
-            moveProc.setProgram(ydotoolPath);
-            moveProc.setProcessEnvironment(env);
-            moveProc.setArguments({"mousemove", QString::number(targetX), QString::number(targetY)});
-            moveProc.start();
-            moveProc.waitForFinished(200);
-
-            QProcess clickProc;
-            clickProc.setProgram(ydotoolPath);
-            clickProc.setProcessEnvironment(env);
-            clickProc.setArguments({"click", "1"});
-            clickProc.start();
-            clickProc.waitForFinished(150);
-            QThread::msleep(60);
-        }
-
         bool sent = false;
         const int burst = std::max(1, kScrollLinesPerTick * 2);
         for (int i = 0; i < burst; ++i) {
@@ -383,7 +344,6 @@ void CaptureOverlay::simulateScrollDown()
             for (const QString& keyName : keyVariants) {
                 QProcess keyProc;
                 keyProc.setProgram(wtypePath);
-                keyProc.setProcessEnvironment(env);
                 keyProc.setArguments({"-k", keyName});
                 keyProc.start();
                 if (keyProc.waitForFinished(180) && keyProc.exitCode() == 0) {
@@ -401,38 +361,6 @@ void CaptureOverlay::simulateScrollDown()
         std::fprintf(stderr,
                      "[CaptureOverlay] Auto-scroll: wtype PageDown sent=%s\n",
                      sent ? "true" : "false");
-        return;
-    }
-
-    if (canUseYdotool) {
-        QProcess moveProc;
-        moveProc.setProgram(ydotoolPath);
-        moveProc.setProcessEnvironment(env);
-        moveProc.setArguments({"mousemove", QString::number(targetX), QString::number(targetY)});
-        moveProc.start();
-        moveProc.waitForFinished(200);
-
-        QProcess clickProc;
-        clickProc.setProgram(ydotoolPath);
-        clickProc.setProcessEnvironment(env);
-        clickProc.setArguments({"click", "1"});
-        clickProc.start();
-        clickProc.waitForFinished(150);
-
-        QThread::msleep(60);
-
-        const int wheelSteps = std::max(1, kScrollLinesPerTick);
-        for (int i = 0; i < wheelSteps; ++i) {
-            QProcess wheelProc;
-            wheelProc.setProgram(ydotoolPath);
-            wheelProc.setProcessEnvironment(env);
-            wheelProc.setArguments({"click", "5"});
-            wheelProc.start();
-            wheelProc.waitForFinished(90);
-        }
-
-        restoreMouseCapture();
-        std::fprintf(stderr, "[CaptureOverlay] Auto-scroll: ydotool wheel-down sent\n");
         return;
     }
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -79,7 +79,6 @@ The daemon is a single long-running background process that:
 - Handles capture and recording operations in-process (no subprocess spawn, no GTK cold-start delay)
 - Provides D-Bus IPC at `org.apexshot.Daemon` for single-instance coordination
 - Manages recording timer state and preview overlay lifecycle
-- Auto-starts `ydotoold` for scroll capture on Wayland
 - Emits `TrackedWindowOpened`/`TrackedWindowClosed` signals for GNOME extension window stacking
 
 **Key D-Bus interfaces:**

--- a/docs/FLATHUB_LAUNCH_PLAN.md
+++ b/docs/FLATHUB_LAUNCH_PLAN.md
@@ -172,7 +172,6 @@ with a portal/library call, or feature-gated off.
 | `gtk-launch` | `daemon/mod.rs:1812`, `hotkeys/mod.rs:318` | Self-relaunch differs in Flatpak; rework or gate off. |
 | `pacman`/`dpkg-query`/`rpm` | `main.rs:631-651` | Package detection is meaningless in Flatpak. Gate off. |
 | `hyprctl`, `swaymsg` | `hotkeys/mod.rs:1065,1103` | Config reload for compositor keybinds; not reachable. Gate off. |
-| `ydotoold`, `pgrep` | `daemon/mod.rs:532-545` | Gate off. |
 | `wget`/`curl`/`unzip` | in-app extension installer | Gate off with the extension installer. |
 
 ### 2.2 The Qt5 overlay

--- a/src/capture/editor.rs
+++ b/src/capture/editor.rs
@@ -80,7 +80,7 @@ mod tests {
             constrained_drag_endpoint(
                 Tool::Line,
                 Point { x: 4.0, y: 4.0 },
-                Point { x: 18.0, y: 9.0 },
+                Point { x: 18.0, y: 7.0 },
                 true,
             ),
             Point { x: 18.0, y: 4.0 }
@@ -94,6 +94,19 @@ mod tests {
                 true,
             ),
             Point { x: 22.0, y: 22.0 }
+        );
+    }
+
+    #[test]
+    fn constrained_drag_endpoint_snaps_line_to_diagonal_when_shift_is_pressed() {
+        assert_eq!(
+            constrained_drag_endpoint(
+                Tool::Line,
+                Point { x: 4.0, y: 4.0 },
+                Point { x: 18.0, y: 13.0 },
+                true,
+            ),
+            Point { x: 18.0, y: 18.0 }
         );
     }
 
@@ -1357,7 +1370,7 @@ mod tests {
     }
 
     #[test]
-    fn draft_line_with_shift_snaps_to_axis() {
+    fn draft_line_with_shift_snaps_to_aligned_angle() {
         let mut state = EditorState::new(RgbaImage::new(20, 20));
         state.set_tool(Tool::Line);
         state.drag_shift_active = true;
@@ -1367,7 +1380,7 @@ mod tests {
         match state.draft_action().unwrap() {
             AnnotationAction::Line { start, end, .. } => {
                 assert_eq!(start, Point { x: 2.0, y: 3.0 });
-                assert_eq!(end, Point { x: 2.0, y: 13.0 });
+                assert_eq!(end, Point { x: 12.0, y: 13.0 });
             }
             other => panic!("unexpected draft action: {:?}", other),
         }

--- a/src/capture/editor/render.rs
+++ b/src/capture/editor/render.rs
@@ -3048,9 +3048,9 @@ pub fn draw_canvas_checkerboard_background(
     let height = height.max(1) as f64;
 
     let (base_dark, tile_dark) = if light {
-        ((0.965, 0.965, 0.972), (0.910, 0.910, 0.922))
+        ((0.965, 0.969, 0.984), (0.941, 0.945, 0.961))
     } else {
-        ((0.075, 0.075, 0.081), (0.095, 0.095, 0.102))
+        ((0.078, 0.078, 0.078), (0.114, 0.114, 0.114))
     };
     let (base_r, base_g, base_b, tile_r, tile_g, tile_b) = if let Some(color) = tint {
         let alpha = color.a.clamp(0.0, 1.0);

--- a/src/capture/editor/types.rs
+++ b/src/capture/editor/types.rs
@@ -682,15 +682,25 @@ pub fn constrained_drag_endpoint(
 
     match tool {
         Tool::Line | Tool::Arrow => {
-            if (end.x - start.x).abs() >= (end.y - start.y).abs() {
+            let dx = end.x - start.x;
+            let dy = end.y - start.y;
+            let max = dx.abs().max(dy.abs());
+
+            let axis_threshold = 1.0 + std::f64::consts::SQRT_2;
+            if dx.abs() >= dy.abs() * axis_threshold {
                 Point {
                     x: end.x,
                     y: start.y,
                 }
-            } else {
+            } else if dy.abs() >= dx.abs() * axis_threshold {
                 Point {
                     x: start.x,
                     y: end.y,
+                }
+            } else {
+                Point {
+                    x: start.x + max * dx.signum(),
+                    y: start.y + max * dy.signum(),
                 }
             }
         }

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -150,13 +150,14 @@ pub fn install_editor_css() {
             }
 
             .editor-toolbar {
-                padding: 4px 10px 4px 12px;
-                background-color: #141414;
-                border-bottom: 1px solid alpha(white, 0.06);
-                border-radius: 10px 10px 0 0;
+                padding: 6px 12px;
+                background-color: #171717;
+                border: none;
+                border-radius: 9px;
+                box-shadow: none;
             }
 
-            .editor-toolbar button.recording-editor-traffic-btn {
+            button.recording-editor-traffic-btn {
                 min-width: 24px;
                 min-height: 24px;
                 padding: 0;
@@ -170,13 +171,13 @@ pub fn install_editor_css() {
                 outline: none;
             }
 
-            .editor-toolbar button.recording-editor-traffic-btn image {
+            button.recording-editor-traffic-btn image {
                 -gtk-icon-size: 14px;
             }
 
-            .editor-toolbar button.recording-editor-traffic-btn:hover,
-            .editor-toolbar button.recording-editor-traffic-btn:active,
-            .editor-toolbar button.recording-editor-traffic-btn:focus {
+            button.recording-editor-traffic-btn:hover,
+            button.recording-editor-traffic-btn:active,
+            button.recording-editor-traffic-btn:focus {
                 background-color: rgba(255, 255, 255, 0.10);
                 background-image: none;
                 color: #ffffff;
@@ -185,15 +186,25 @@ pub fn install_editor_css() {
                 box-shadow: none;
             }
 
-            .editor-toolbar button.recording-editor-traffic-btn:hover image,
-            .editor-toolbar button.recording-editor-traffic-btn:active image,
-            .editor-toolbar button.recording-editor-traffic-btn:focus image {
+            button.recording-editor-traffic-btn:hover image,
+            button.recording-editor-traffic-btn:active image,
+            button.recording-editor-traffic-btn:focus image {
                 color: #ffffff;
             }
 
             .editor-toolbar-wm-controls {
                 padding-left: 6px;
                 border-left: 1px solid rgba(255, 255, 255, 0.06);
+            }
+
+            .editor-sidebar-utility-controls {
+                padding: 12px 16px 10px;
+                border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+            }
+
+            .editor-sidebar-utility-controls .editor-toolbar-wm-controls {
+                padding: 8px 0 0;
+                border-left: none;
             }
 
             .editor-toolbar-brand {
@@ -1134,6 +1145,71 @@ pub fn install_editor_css() {
                 border: none;
             }
 
+            .editor-floating-zoom {
+                padding: 6px;
+                background: #171717;
+                border-radius: 9px;
+            }
+
+            .editor-floating-history {
+                padding: 6px;
+                background: #171717;
+                border-radius: 9px;
+            }
+
+            .editor-floating-history button.editor-tool-button {
+                min-width: 34px;
+                min-height: 34px;
+            }
+
+            .editor-canvas-frame scrollbar {
+                opacity: 0;
+                min-width: 0;
+                min-height: 0;
+            }
+
+            .editor-floating-zoom button.editor-footer-zoom-button {
+                min-height: 34px;
+                padding: 0 14px;
+            }
+
+            button.editor-floating-zoom-step {
+                min-width: 34px;
+                min-height: 34px;
+                padding: 0;
+                border: none;
+                border-radius: 5px;
+                background: transparent;
+                color: rgba(255, 255, 255, 0.78);
+                font-size: 15px;
+            }
+
+            button.editor-floating-zoom-step:hover {
+                background: alpha(white, 0.06);
+                color: #ffffff;
+            }
+
+            .editor-sidebar-actions {
+                padding: 10px 16px 16px;
+            }
+
+            button.editor-sidebar-action-button {
+                min-width: 28px;
+                min-height: 28px;
+                border-radius: 5px;
+                background: transparent;
+            }
+
+            button.editor-sidebar-action-button:hover {
+                background: alpha(white, 0.10);
+            }
+
+            .editor-sidebar-actions button.editor-done-button {
+                min-width: 92px;
+                min-height: 32px;
+                padding: 0 16px;
+            }
+
             .editor-footer-zoom-label {
                 color: inherit;
                 font-size: 12px;
@@ -1257,8 +1333,7 @@ pub fn install_editor_css() {
             }
 
             .editor-root.editor-theme-dark .editor-toolbar {
-                background-color: #141414;
-                border-bottom-color: alpha(white, 0.06);
+                background-color: #171717;
             }
 
             .editor-root.editor-theme-dark .editor-footer {
@@ -1287,7 +1362,6 @@ pub fn install_editor_css() {
 
             .editor-root.editor-theme-light .editor-toolbar {
                 background-color: #f6f7fb;
-                border-bottom-color: alpha(#111827, 0.06);
             }
 
             .editor-root.editor-theme-light .editor-footer {
@@ -1302,6 +1376,31 @@ pub fn install_editor_css() {
             .editor-root.editor-theme-light button.editor-footer-zoom-button:hover {
                 background: alpha(#111827, 0.06);
                 color: #1d2129;
+            }
+
+            .editor-root.editor-theme-light .editor-floating-zoom {
+                background: #f6f7fb;
+            }
+
+            .editor-root.editor-theme-light .editor-floating-history {
+                background: #f6f7fb;
+            }
+
+            .editor-root.editor-theme-light button.editor-floating-zoom-step {
+                color: alpha(#1d2129, 0.78);
+            }
+
+            .editor-root.editor-theme-light button.editor-floating-zoom-step:hover {
+                background: alpha(#111827, 0.06);
+                color: #1d2129;
+            }
+
+            .editor-root.editor-theme-light button.editor-sidebar-action-button {
+                background: transparent;
+            }
+
+            .editor-root.editor-theme-light button.editor-sidebar-action-button:hover {
+                background: alpha(#111827, 0.10);
             }
 
             .editor-root.editor-theme-light .editor-footer-zoom-popup {
@@ -1544,7 +1643,10 @@ pub fn install_editor_css() {
             /* Inspector / right side panels */
             .editor-root.editor-theme-light .editor-right-inspector {
                 background: #eef0f5;
-                border-left: 1px solid alpha(#111827, 0.06);
+                border-left: none;
+            }
+            .editor-root.editor-theme-light .editor-sidebar-utility-controls {
+                border-bottom-color: alpha(#111827, 0.06);
             }
             .editor-root.editor-theme-light .editor-inspector-tabs,
             .editor-root.editor-theme-light .editor-inspector-section {
@@ -1873,19 +1975,19 @@ pub fn install_editor_css() {
             }
 
             /* Window controls (traffic buttons) */
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn {
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn {
                 color: alpha(#1d2129, 0.65);
             }
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:hover,
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:active,
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:focus {
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:hover,
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:active,
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:focus {
                 background-color: alpha(#111827, 0.10);
                 color: alpha(#1d2129, 0.65);
             }
 
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:hover image,
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:active image,
-            .editor-root.editor-theme-light .editor-toolbar button.recording-editor-traffic-btn:focus image {
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:hover image,
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:active image,
+            .editor-root.editor-theme-light button.recording-editor-traffic-btn:focus image {
                 color: alpha(#1d2129, 0.65);
             }
 
@@ -1917,7 +2019,7 @@ pub fn install_editor_css() {
             .editor-right-inspector {
                 min-width: 210px;
                 background: #141414;
-                border-left: 1px solid alpha(white, 0.06);
+                border-left: none;
                 padding: 0;
             }
 

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -5,6 +5,8 @@ use gtk4::{
 };
 use std::process::Command;
 
+pub const EDITOR_MIN_WINDOW_WIDTH: i32 = 980;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EditorToolIcon {
     Named(String),
@@ -151,7 +153,7 @@ pub fn install_editor_css() {
 
             .editor-toolbar {
                 padding: 6px 12px;
-                background-color: #171717;
+                background-color: #0f0f0f;
                 border: none;
                 border-radius: 9px;
                 box-shadow: none;
@@ -203,7 +205,7 @@ pub fn install_editor_css() {
             }
 
             .editor-sidebar-utility-controls .editor-toolbar-wm-controls {
-                padding: 8px 0 0;
+                padding: 0;
                 border-left: none;
             }
 
@@ -1147,13 +1149,13 @@ pub fn install_editor_css() {
 
             .editor-floating-zoom {
                 padding: 6px;
-                background: #171717;
+                background: #0f0f0f;
                 border-radius: 9px;
             }
 
             .editor-floating-history {
                 padding: 6px;
-                background: #171717;
+                background: #0f0f0f;
                 border-radius: 9px;
             }
 
@@ -1219,7 +1221,7 @@ pub fn install_editor_css() {
             /* --- Zoom popup (flat surface, no glass) --- */
             .editor-footer-zoom-popup {
                 padding: 0;
-                background: #1a1a1a;
+                background: #0f0f0f;
                 border: 1px solid alpha(white, 0.06);
                 border-radius: 10px;
                 min-width: 240px;
@@ -1333,7 +1335,7 @@ pub fn install_editor_css() {
             }
 
             .editor-root.editor-theme-dark .editor-toolbar {
-                background-color: #171717;
+                background-color: #0f0f0f;
             }
 
             .editor-root.editor-theme-dark .editor-footer {
@@ -1361,7 +1363,7 @@ pub fn install_editor_css() {
             }
 
             .editor-root.editor-theme-light .editor-toolbar {
-                background-color: #f6f7fb;
+                background-color: #eef0f5;
             }
 
             .editor-root.editor-theme-light .editor-footer {
@@ -1379,11 +1381,11 @@ pub fn install_editor_css() {
             }
 
             .editor-root.editor-theme-light .editor-floating-zoom {
-                background: #f6f7fb;
+                background: #eef0f5;
             }
 
             .editor-root.editor-theme-light .editor-floating-history {
-                background: #f6f7fb;
+                background: #eef0f5;
             }
 
             .editor-root.editor-theme-light button.editor-floating-zoom-step {
@@ -1404,7 +1406,7 @@ pub fn install_editor_css() {
             }
 
             .editor-root.editor-theme-light .editor-footer-zoom-popup {
-                background: #ffffff;
+                background: #eef0f5;
                 border-color: alpha(#111827, 0.10);
             }
 
@@ -1642,7 +1644,7 @@ pub fn install_editor_css() {
 
             /* Inspector / right side panels */
             .editor-root.editor-theme-light .editor-right-inspector {
-                background: #eef0f5;
+                background: alpha(#111827, 0.04);
                 border-left: none;
             }
             .editor-root.editor-theme-light .editor-sidebar-utility-controls {
@@ -1850,7 +1852,7 @@ pub fn install_editor_css() {
             }
             .editor-root.editor-theme-light .editor-inspector-section-body {
                 background: #ffffff;
-                border: 1px solid alpha(#111827, 0.06);
+                border: none;
             }
             .editor-root.editor-theme-light .editor-inspector-placeholder {
                 color: alpha(#1d2129, 0.62);
@@ -2018,7 +2020,7 @@ pub fn install_editor_css() {
 
             .editor-right-inspector {
                 min-width: 210px;
-                background: #141414;
+                background: alpha(black, 0.25);
                 border-left: none;
                 padding: 0;
             }
@@ -2094,8 +2096,8 @@ pub fn install_editor_css() {
             }
 
             .editor-inspector-section-body {
-                background: alpha(white, 0.04);
-                border: 1px solid alpha(white, 0.06);
+                background: alpha(white, 0.06);
+                border: none;
                 border-radius: 6px;
             }
 
@@ -3221,7 +3223,7 @@ pub fn recommended_window_size_with_extra_width(
     let default_height = 820;
 
     (
-        default_width.clamp(980.min(max_width), max_width.max(1)),
+        default_width.clamp(EDITOR_MIN_WINDOW_WIDTH.min(max_width), max_width.max(1)),
         default_height.clamp(560.min(max_height), max_height.max(1)),
     )
 }
@@ -3377,44 +3379,50 @@ pub fn install_edge_resize(root: &impl IsA<gtk4::Widget>, window: &gtk4::Applica
     root.add_controller(resize_click);
 }
 
-pub fn install_window_drag(toolbar: &impl IsA<gtk4::Widget>, window: &gtk4::ApplicationWindow) {
+fn is_interactive_widget(widget: &gtk4::Widget) -> bool {
+    let mut current = Some(widget.clone());
+    while let Some(widget) = current {
+        if matches!(
+            widget.type_().name(),
+            "GtkButton"
+                | "GtkToggleButton"
+                | "GtkMenuButton"
+                | "GtkEntry"
+                | "GtkScale"
+                | "GtkDropDown"
+                | "GtkCheckButton"
+                | "GtkPopover"
+        ) {
+            return true;
+        }
+        current = widget.parent();
+    }
+    false
+}
+
+fn install_window_drag_in_region(
+    widget: &impl IsA<gtk4::Widget>,
+    window: &gtk4::ApplicationWindow,
+    max_y: Option<f64>,
+) {
     use gtk4::GestureClick;
 
     let drag_window_gesture = GestureClick::new();
-    drag_window_gesture.set_button(0); // Accept any button
+    drag_window_gesture.set_button(1);
     let window_drag = window.downgrade();
     drag_window_gesture.connect_pressed(move |gesture, _, x, y| {
-        // Check if the click was on an interactive widget (button, entry, etc.)
+        if max_y.is_some_and(|max_y| y > max_y) {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
+            return;
+        }
+
         let Some(widget) = gesture.widget() else {
             return;
         };
-
-        // Get the widget at the click position
         let picked = widget.pick(x, y, gtk4::PickFlags::DEFAULT);
-
-        // Only drag if clicked on empty space (not on buttons or other interactive widgets)
-        if let Some(picked) = picked {
-            let type_name = picked.type_().name();
-            if type_name == "GtkButton"
-                || type_name == "GtkToggleButton"
-                || type_name == "GtkMenuButton"
-                || type_name == "GtkEntry"
-                || type_name == "GtkScale"
-                || type_name == "GtkPopover"
-            {
-                return; // Don't drag if clicked on interactive widget
-            }
-
-            // Also check for buttons inside boxes
-            if let Some(parent) = picked.parent() {
-                let parent_type = parent.type_().name();
-                if parent_type == "GtkButton"
-                    || parent_type == "GtkToggleButton"
-                    || parent_type == "GtkMenuButton"
-                {
-                    return;
-                }
-            }
+        if picked.as_ref().is_some_and(is_interactive_widget) {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
+            return;
         }
 
         let Some(window) = window_drag.upgrade() else {
@@ -3434,7 +3442,18 @@ pub fn install_window_drag(toolbar: &impl IsA<gtk4::Widget>, window: &gtk4::Appl
         };
         toplevel.begin_move(&device, gesture.current_button() as i32, x, y, event.time());
     });
-    toolbar.add_controller(drag_window_gesture);
+    widget.add_controller(drag_window_gesture);
+}
+
+pub fn install_window_drag(toolbar: &impl IsA<gtk4::Widget>, window: &gtk4::ApplicationWindow) {
+    install_window_drag_in_region(toolbar, window, None);
+}
+
+pub fn install_top_bar_window_drag(
+    root: &impl IsA<gtk4::Widget>,
+    window: &gtk4::ApplicationWindow,
+) {
+    install_window_drag_in_region(root, window, Some(64.0));
 }
 
 #[cfg(test)]

--- a/src/capture/editor/ui_support.rs
+++ b/src/capture/editor/ui_support.rs
@@ -7,6 +7,10 @@ use std::process::Command;
 
 pub const EDITOR_MIN_WINDOW_WIDTH: i32 = 980;
 
+/// Reserved strip above the canvas for the floating toolbar + window drag.
+/// The image viewport starts below this so zoomed content cannot cover the tools.
+pub const EDITOR_TOP_CHROME_HEIGHT: i32 = 56;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EditorToolIcon {
     Named(String),
@@ -151,6 +155,15 @@ pub fn install_editor_css() {
                 box-shadow: none;
             }
 
+            .editor-top-chrome {
+                min-height: 56px;
+                background: none;
+                background-color: transparent;
+                background-image: none;
+                border: none;
+                box-shadow: none;
+            }
+
             .editor-toolbar {
                 padding: 6px 12px;
                 background-color: #0f0f0f;
@@ -159,7 +172,7 @@ pub fn install_editor_css() {
                 box-shadow: none;
             }
 
-            button.recording-editor-traffic-btn {
+            .editor-root button.recording-editor-traffic-btn {
                 min-width: 24px;
                 min-height: 24px;
                 padding: 0;
@@ -173,13 +186,13 @@ pub fn install_editor_css() {
                 outline: none;
             }
 
-            button.recording-editor-traffic-btn image {
+            .editor-root button.recording-editor-traffic-btn image {
                 -gtk-icon-size: 14px;
             }
 
-            button.recording-editor-traffic-btn:hover,
-            button.recording-editor-traffic-btn:active,
-            button.recording-editor-traffic-btn:focus {
+            .editor-root button.recording-editor-traffic-btn:hover,
+            .editor-root button.recording-editor-traffic-btn:active,
+            .editor-root button.recording-editor-traffic-btn:focus {
                 background-color: rgba(255, 255, 255, 0.10);
                 background-image: none;
                 color: #ffffff;
@@ -188,9 +201,9 @@ pub fn install_editor_css() {
                 box-shadow: none;
             }
 
-            button.recording-editor-traffic-btn:hover image,
-            button.recording-editor-traffic-btn:active image,
-            button.recording-editor-traffic-btn:focus image {
+            .editor-root button.recording-editor-traffic-btn:hover image,
+            .editor-root button.recording-editor-traffic-btn:active image,
+            .editor-root button.recording-editor-traffic-btn:focus image {
                 color: #ffffff;
             }
 
@@ -1311,22 +1324,6 @@ pub fn install_editor_css() {
                 margin: 4px 10px;
             }
 
-            .editor-footer-zoom-mouse-hints {
-                padding: 12px 10px 14px 10px;
-            }
-
-            .editor-footer-zoom-mouse-hint-text {
-                font-size: 10px;
-                color: rgba(255, 255, 255, 0.50);
-                line-height: 1.35;
-            }
-
-            .editor-footer-zoom-mouse-drawing {
-                min-width: 60px;
-                min-height: 60px;
-                margin: 0 8px;
-            }
-
             .editor-root.editor-theme-dark {
                 background-color: #141414;
                 color: #f1f1f3;
@@ -1456,14 +1453,6 @@ pub fn install_editor_css() {
                 background: alpha(#111827, 0.08);
             }
 
-            .editor-root.editor-theme-light .editor-footer-zoom-mouse-hint-text {
-                color: alpha(#111827, 0.54);
-            }
-
-            .editor-root.editor-theme-light .editor-footer-zoom-mouse-drawing {
-                color: #1d2129;
-            }
-
             .editor-footer-zoom-popup.editor-theme-light {
                 background: #ffffff;
                 border-color: alpha(#111827, 0.10);
@@ -1515,14 +1504,6 @@ pub fn install_editor_css() {
 
             .editor-footer-zoom-popup.editor-theme-light .editor-footer-zoom-separator {
                 background: alpha(#111827, 0.08);
-            }
-
-            .editor-footer-zoom-popup.editor-theme-light .editor-footer-zoom-mouse-hint-text {
-                color: alpha(#111827, 0.54);
-            }
-
-            .editor-footer-zoom-popup.editor-theme-light .editor-footer-zoom-mouse-drawing {
-                color: #1d2129;
             }
 
             .editor-root.editor-theme-light button.editor-tool-button image,
@@ -1624,20 +1605,10 @@ pub fn install_editor_css() {
             .editor-root.editor-theme-light .editor-footer-zoom-separator {
                 background: alpha(#111827, 0.06);
             }
-            .editor-root.editor-theme-light .editor-footer-zoom-mouse-hint-text {
-                color: alpha(#1d2129, 0.55);
-            }
             .editor-root.editor-theme-light button.editor-footer-zoom-action-btn {
                 color: alpha(#1d2129, 0.85);
             }
             .editor-root.editor-theme-light .editor-footer-zoom-shortcut-box {
-                background: alpha(#111827, 0.04);
-                border: 1px solid alpha(#111827, 0.10);
-            }
-            .editor-root.editor-theme-light .editor-footer-zoom-mouse-hints {
-                background: transparent;
-            }
-            .editor-root.editor-theme-light .editor-footer-zoom-mouse-drawing {
                 background: alpha(#111827, 0.04);
                 border: 1px solid alpha(#111827, 0.10);
             }
@@ -3130,6 +3101,8 @@ pub fn icon_tool_button(icon_name: &str, tooltip: &str) -> Button {
     let button = Button::new();
     button.set_child(Some(&image));
     button.set_has_frame(false);
+    // Keep focus on the canvas so Space continues to pan after tool clicks.
+    button.set_focusable(false);
     button.set_tooltip_text(Some(tooltip));
     button.add_css_class("editor-tool-button");
     button
@@ -3159,6 +3132,7 @@ pub fn footer_icon_button(icon_name: &str, tooltip: &str) -> (Button, Image) {
     let button = Button::new();
     button.set_child(Some(&image));
     button.set_has_frame(false);
+    button.set_focusable(false);
     button.set_tooltip_text(Some(tooltip));
     button.add_css_class("editor-footer-icon-button");
 
@@ -3382,6 +3356,18 @@ pub fn install_edge_resize(root: &impl IsA<gtk4::Widget>, window: &gtk4::Applica
 fn is_interactive_widget(widget: &gtk4::Widget) -> bool {
     let mut current = Some(widget.clone());
     while let Some(widget) = current {
+        // Canvas lives under the floating top bar after the redesign. Treat the
+        // whole canvas subtree as interactive so the top-64px window-drag
+        // handler does not call begin_move() over DrawingArea hits.
+        if widget.has_css_class("editor-canvas")
+            || widget.has_css_class("editor-canvas-frame")
+            || widget.has_css_class("editor-canvas-workspace")
+            || widget.has_css_class("editor-floating-zoom")
+            || widget.has_css_class("editor-floating-history")
+        {
+            return true;
+        }
+
         if matches!(
             widget.type_().name(),
             "GtkButton"
@@ -3392,6 +3378,11 @@ fn is_interactive_widget(widget: &gtk4::Widget) -> bool {
                 | "GtkDropDown"
                 | "GtkCheckButton"
                 | "GtkPopover"
+                | "GtkDrawingArea"
+                | "GtkScrolledWindow"
+                | "GtkViewport"
+                | "GtkText"
+                | "GtkTextView"
         ) {
             return true;
         }
@@ -3426,20 +3417,26 @@ fn install_window_drag_in_region(
         }
 
         let Some(window) = window_drag.upgrade() else {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
             return;
         };
         let Some(event) = gesture.current_event() else {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
             return;
         };
         let Some(device) = event.device() else {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
             return;
         };
         let Some(surface) = window.surface() else {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
             return;
         };
         let Ok(toplevel) = surface.downcast::<gdk::Toplevel>() else {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
             return;
         };
+        gesture.set_state(gtk4::EventSequenceState::Claimed);
         toplevel.begin_move(&device, gesture.current_button() as i32, x, y, event.time());
     });
     widget.add_controller(drag_window_gesture);
@@ -3453,7 +3450,7 @@ pub fn install_top_bar_window_drag(
     root: &impl IsA<gtk4::Widget>,
     window: &gtk4::ApplicationWindow,
 ) {
-    install_window_drag_in_region(root, window, Some(64.0));
+    install_window_drag_in_region(root, window, Some(f64::from(EDITOR_TOP_CHROME_HEIGHT)));
 }
 
 #[cfg(test)]
@@ -3462,6 +3459,21 @@ mod tests {
         arrow_style_toolbar_icon, custom_toolbar_icon_inset, toolbar_icon_size, EditorToolIcon,
     };
     use crate::capture::editor::types::ArrowStyle;
+
+    #[test]
+    fn window_drag_hit_test_treats_canvas_as_interactive() {
+        let source = include_str!("ui_support.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("\"GtkDrawingArea\"")
+                && production_source.contains("\"GtkScrolledWindow\"")
+                && production_source.contains("editor-canvas-frame")
+                && production_source.contains("editor-canvas-workspace")
+                && production_source.contains("EDITOR_TOP_CHROME_HEIGHT")
+                && production_source.contains(".editor-top-chrome"),
+            "top-bar window drag must not begin_move over the canvas subtree"
+        );
+    }
 
     #[test]
     fn arrow_style_toolbar_icon_maps_each_style_to_a_custom_preview() {
@@ -3667,7 +3679,6 @@ mod tests {
                 && production_source.contains(".editor-footer-zoom-popup.editor-theme-light {")
                 && production_source.contains("background: #ffffff;")
                 && production_source.contains(".editor-footer-zoom-popup.editor-theme-light .editor-footer-zoom-row {")
-                && production_source.contains(".editor-footer-zoom-popup.editor-theme-light .editor-footer-zoom-mouse-drawing {")
                 && !production_source.contains(".editor-footer-zoom-popup {\n                min-height: 100%;")
                 && !production_source.contains(".editor-footer-zoom-popup {\n                width: 210px;"),
             "Footer zoom popover should use flat dark/light surfaces matching the settings UI language without becoming a full-height or fixed-width sidebar",

--- a/src/capture/editor/window/background_panel.rs
+++ b/src/capture/editor/window/background_panel.rs
@@ -722,7 +722,6 @@ pub(super) fn build_background_panel(
             .map(|(b, d, s)| (b.clone(), d.clone(), s.clone()))
             .collect::<Vec<_>>();
         let gradients_toggle_btn = gradients_toggle_btn.clone();
-        let window_weak = window.downgrade();
         move |_| {
             let is_collapsed = gradients_collapsed.get();
             gradients_collapsed.set(!is_collapsed);
@@ -737,16 +736,7 @@ pub(super) fn build_background_panel(
                 gradients_collapsed.get(),
                 density,
             );
-
-            if let Some(win) = window_weak.upgrade() {
-                if !is_collapsed {
-                    // Collapsing: force the toplevel to shrink to its new natural size.
-                    // queue_resize() alone won't shrink a realized window, so we reset the
-                    // default size to (1, 1) which makes GTK reflow to the natural minimum.
-                    win.set_default_size(1, 1);
-                }
-                win.queue_resize();
-            }
+            gradients_grid.queue_resize();
         }
     });
 
@@ -1467,6 +1457,17 @@ mod tests {
         assert!(
             !production_source.contains("shadow_section.append(&alignment_section);"),
             "alignment section should no longer be nested under the shadow section",
+        );
+    }
+
+    #[test]
+    fn collapsing_gradients_never_resizes_the_editor_window() {
+        let source = include_str!("background_panel.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+
+        assert!(
+            !production_source.contains("set_default_size(1, 1)"),
+            "collapsing gradients must not resize the editor to its minimum size"
         );
     }
 

--- a/src/capture/editor/window/canvas.rs
+++ b/src/capture/editor/window/canvas.rs
@@ -76,7 +76,7 @@ pub(super) fn build_canvas_shell(
     canvas_scroller.set_vexpand(true);
     canvas_scroller.set_has_frame(false);
     canvas_scroller.set_policy(gtk4::PolicyType::Automatic, gtk4::PolicyType::Automatic);
-    canvas_scroller.set_overlay_scrolling(false);
+    canvas_scroller.set_overlay_scrolling(true);
     canvas_scroller.set_child(Some(&canvas_overlay));
 
     let canvas_eyedropper_ring = DrawingArea::new();

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -706,7 +706,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     );
     let apply_zoom_change_scroll = apply_zoom_change.clone();
     let zoom_level_scroll = zoom_level.clone();
-    scroll_controller.connect_scroll(move |controller, _dx, dy| {
+    scroll_controller.connect_scroll(move |controller, dx, dy| {
         if !controller
             .current_event_state()
             .contains(gdk::ModifierType::CONTROL_MASK)
@@ -714,9 +714,11 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
             return glib::Propagation::Proceed;
         }
 
-        if dy < 0.0 {
+        // Prefer vertical; fall back to horizontal for devices that only emit dx.
+        let delta = if dy != 0.0 { dy } else { dx };
+        if delta < 0.0 {
             apply_zoom_change_scroll(zoom_level_scroll.get() * ZOOM_STEP);
-        } else if dy > 0.0 {
+        } else if delta > 0.0 {
             apply_zoom_change_scroll(zoom_level_scroll.get() / ZOOM_STEP);
         }
         glib::Propagation::Stop
@@ -1752,6 +1754,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
             let vadj = canvas_scroller_space_pan_begin.vadjustment();
             space_pan_origin_begin.set((hadj.value(), vadj.value()));
             space_pan_dragging_begin.set(true);
+            gesture.set_state(gtk4::EventSequenceState::Claimed);
             if let Some(window) = window_space_pan_begin.upgrade() {
                 set_window_cursor_name(&window, Some("grabbing"));
             }
@@ -3363,6 +3366,75 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
 
     drawing_area.add_controller(motion);
 
+    // Capture-phase Space handler: tool/chrome buttons are often focusable and
+    // would activate on Space in the bubble phase, which breaks hand-pan after
+    // the first tool click. Capture runs before the focused widget.
+    let space_pan_controller = EventControllerKey::new();
+    space_pan_controller.set_propagation_phase(gtk4::PropagationPhase::Capture);
+    let space_pan_active_capture = space_pan_active.clone();
+    let space_pan_dragging_capture = space_pan_dragging.clone();
+    let eyedropper_mode_space = eyedropper_mode.clone();
+    let state_space = state.clone();
+    let window_space = window.downgrade();
+    let drawing_area_space = drawing_area.downgrade();
+    space_pan_controller.connect_key_pressed(move |_, key, _, _| {
+        if key != gdk::Key::space || eyedropper_mode_space.get() {
+            return glib::Propagation::Proceed;
+        }
+
+        // Canvas text editing and GTK entries still need Space as a character.
+        if state_space.lock().unwrap().active_text_input.is_some() {
+            return glib::Propagation::Proceed;
+        }
+        if let Some(window) = window_space.upgrade() {
+            if let Some(focused) = gtk4::prelude::GtkWindowExt::focus(&window) {
+                if focused.is::<gtk4::Entry>() || focused.is::<gtk4::Text>() {
+                    return glib::Propagation::Proceed;
+                }
+            }
+        }
+
+        space_pan_active_capture.set(true);
+        if let Some(window) = window_space.upgrade() {
+            set_window_cursor_name(
+                &window,
+                Some(if space_pan_dragging_capture.get() {
+                    "grabbing"
+                } else {
+                    "grab"
+                }),
+            );
+        }
+        if let Some(area) = drawing_area_space.upgrade() {
+            area.grab_focus();
+        }
+        glib::Propagation::Stop
+    });
+    let space_pan_active_released = space_pan_active.clone();
+    let space_pan_dragging_released = space_pan_dragging.clone();
+    let eyedropper_mode_released = eyedropper_mode.clone();
+    let window_released = window.downgrade();
+    space_pan_controller.connect_key_released(move |_, key, _, _| {
+        if key != gdk::Key::space {
+            return;
+        }
+
+        space_pan_active_released.set(false);
+        if !space_pan_dragging_released.get() {
+            if let Some(window) = window_released.upgrade() {
+                set_window_cursor_name(
+                    &window,
+                    if eyedropper_mode_released.get() {
+                        Some("crosshair")
+                    } else {
+                        None
+                    },
+                );
+            }
+        }
+    });
+    window.add_controller(space_pan_controller);
+
     let key_controller = EventControllerKey::new();
     let state_keys = state.clone();
     let drawing_area_keys = drawing_area.downgrade();
@@ -3381,8 +3453,6 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let zoom_level_keys = zoom_level.clone();
     let update_canvas_content_size_keys = update_canvas_content_size.clone();
     let zoom_popup_keys = zoom_popup.clone();
-    let space_pan_active_keys = space_pan_active.clone();
-    let space_pan_dragging_keys = space_pan_dragging.clone();
 
     key_controller.connect_key_pressed(move |_, key, _, modifiers| {
         if key == gdk::Key::Escape && eyedropper_mode_keys.get() {
@@ -3447,21 +3517,6 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
                     return glib::Propagation::Stop;
                 }
             }
-        }
-
-        if key == gdk::Key::space && !eyedropper_mode_keys.get() {
-            space_pan_active_keys.set(true);
-            if let Some(window) = window_keys.upgrade() {
-                set_window_cursor_name(
-                    &window,
-                    Some(if space_pan_dragging_keys.get() {
-                        "grabbing"
-                    } else {
-                        "grab"
-                    }),
-                );
-            }
-            return glib::Propagation::Stop;
         }
 
         if ctrl && (pressed == Some('z') || pressed == Some('Z')) {
@@ -3560,29 +3615,6 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
 
         glib::Propagation::Proceed
     });
-    let space_pan_active_released = space_pan_active.clone();
-    let space_pan_dragging_released = space_pan_dragging.clone();
-    let eyedropper_mode_released = eyedropper_mode.clone();
-    let window_released = window.downgrade();
-    key_controller.connect_key_released(move |_, key, _, _| {
-        if key != gdk::Key::space {
-            return;
-        }
-
-        space_pan_active_released.set(false);
-        if !space_pan_dragging_released.get() {
-            if let Some(window) = window_released.upgrade() {
-                set_window_cursor_name(
-                    &window,
-                    if eyedropper_mode_released.get() {
-                        Some("crosshair")
-                    } else {
-                        None
-                    },
-                );
-            }
-        }
-    });
     window.add_controller(key_controller);
 
     let app_weak = app.downgrade();
@@ -3646,9 +3678,10 @@ mod tests {
             production_source.contains("return glib::Propagation::Proceed;")
                 && production_source.contains("if space_pan_active_drag_begin.get() {")
                 && production_source.contains("space_pan_dragging_begin.set(true);")
-                && production_source.contains("if key == gdk::Key::space && !eyedropper_mode_keys.get()")
+                && production_source.contains("space_pan_controller.set_propagation_phase(gtk4::PropagationPhase::Capture)")
+                && production_source.contains("if key != gdk::Key::space || eyedropper_mode_space.get()")
                 && production_source.contains("Some(\"grab\")"),
-            "normal scrolling should reach the canvas scroller while space temporarily enables hand panning"
+            "normal scrolling should reach the canvas scroller while capture-phase space enables hand panning"
         );
     }
 

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -331,6 +331,9 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     } = ctx;
 
     let drag_start_transform = Rc::new(RefCell::new(None::<ViewTransform>));
+    let space_pan_active = Rc::new(Cell::new(false));
+    let space_pan_dragging = Rc::new(Cell::new(false));
+    let space_pan_origin = Rc::new(Cell::new((0.0, 0.0)));
 
     let state_select = state.clone();
     let drawing_area_select = drawing_area.downgrade();
@@ -697,11 +700,20 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     });
 
     let scroll_controller = EventControllerScroll::new(
-        EventControllerScrollFlags::VERTICAL | EventControllerScrollFlags::DISCRETE,
+        EventControllerScrollFlags::VERTICAL
+            | EventControllerScrollFlags::HORIZONTAL
+            | EventControllerScrollFlags::DISCRETE,
     );
     let apply_zoom_change_scroll = apply_zoom_change.clone();
     let zoom_level_scroll = zoom_level.clone();
-    scroll_controller.connect_scroll(move |_, _dx, dy| {
+    scroll_controller.connect_scroll(move |controller, _dx, dy| {
+        if !controller
+            .current_event_state()
+            .contains(gdk::ModifierType::CONTROL_MASK)
+        {
+            return glib::Propagation::Proceed;
+        }
+
         if dy < 0.0 {
             apply_zoom_change_scroll(zoom_level_scroll.get() * ZOOM_STEP);
         } else if dy > 0.0 {
@@ -1726,10 +1738,26 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let transform_drag_begin = transform.clone();
     let drawing_area_begin = drawing_area.downgrade();
     let drag_last_redraw_begin = drag_last_redraw.clone();
+    let space_pan_active_drag_begin = space_pan_active.clone();
+    let space_pan_dragging_begin = space_pan_dragging.clone();
+    let space_pan_origin_begin = space_pan_origin.clone();
+    let canvas_scroller_space_pan_begin = canvas_scroller.clone();
+    let window_space_pan_begin = window.downgrade();
     let apply_crop_btn_drag_begin = apply_crop_btn.clone();
     let update_crop_size_fields_drag_begin = update_crop_size_fields.clone();
     let drag_start_transform_begin = drag_start_transform.clone();
     drag.connect_drag_begin(move |gesture, x, y| {
+        if space_pan_active_drag_begin.get() {
+            let hadj = canvas_scroller_space_pan_begin.hadjustment();
+            let vadj = canvas_scroller_space_pan_begin.vadjustment();
+            space_pan_origin_begin.set((hadj.value(), vadj.value()));
+            space_pan_dragging_begin.set(true);
+            if let Some(window) = window_space_pan_begin.upgrade() {
+                set_window_cursor_name(&window, Some("grabbing"));
+            }
+            return;
+        }
+
         if eyedropper_mode_drag_begin.get() {
             return;
         }
@@ -2214,10 +2242,26 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let transform_drag_update = transform.clone();
     let drawing_area_update = drawing_area.downgrade();
     let drag_last_redraw_update = drag_last_redraw.clone();
+    let space_pan_dragging_update = space_pan_dragging.clone();
+    let space_pan_origin_update = space_pan_origin.clone();
+    let canvas_scroller_space_pan_update = canvas_scroller.clone();
     let update_crop_size_fields_drag_update = update_crop_size_fields.clone();
     let rebuild_effects_async_drag_update = rebuild_effects_async.clone();
     let drag_start_transform_update = drag_start_transform.clone();
     drag.connect_drag_update(move |gesture, offset_x, offset_y| {
+        if space_pan_dragging_update.get() {
+            let hadj = canvas_scroller_space_pan_update.hadjustment();
+            let vadj = canvas_scroller_space_pan_update.vadjustment();
+            let (start_x, start_y) = space_pan_origin_update.get();
+            hadj.set_value(
+                (start_x - offset_x).clamp(hadj.lower(), hadj.upper() - hadj.page_size()),
+            );
+            vadj.set_value(
+                (start_y - offset_y).clamp(vadj.lower(), vadj.upper() - vadj.page_size()),
+            );
+            return;
+        }
+
         if eyedropper_mode_drag_update.get() {
             return;
         }
@@ -2360,12 +2404,29 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let transform_drag_end = transform.clone();
     let drawing_area_end = drawing_area.downgrade();
     let drag_last_redraw_end = drag_last_redraw.clone();
+    let space_pan_active_end = space_pan_active.clone();
+    let space_pan_dragging_end = space_pan_dragging.clone();
+    let window_space_pan_end = window.downgrade();
     let apply_crop_btn_drag_end = apply_crop_btn.clone();
     let update_crop_size_fields_drag_end = update_crop_size_fields.clone();
     let sync_size_control_drag_end = sync_size_control.clone();
     let sync_select_inspector_drag_end = sync_select_inspector.clone();
     let rebuild_effects_async_drag_end = rebuild_effects_async.clone();
     drag.connect_drag_end(move |gesture, offset_x, offset_y| {
+        if space_pan_dragging_end.replace(false) {
+            if let Some(window) = window_space_pan_end.upgrade() {
+                set_window_cursor_name(
+                    &window,
+                    if space_pan_active_end.get() {
+                        Some("grab")
+                    } else {
+                        None
+                    },
+                );
+            }
+            return;
+        }
+
         if eyedropper_mode_drag_end.get() {
             return;
         }
@@ -2517,6 +2578,7 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let eyedropper_point_click = eyedropper_point.clone();
     let eyedropper_rendered_click = eyedropper_rendered.clone();
     let color_popover_canvas_click = color_popover.clone();
+    let space_pan_active_click = space_pan_active.clone();
     let set_picker_panel_visibility_canvas_click = set_picker_panel_visibility.clone();
     let canvas_eyedropper_ring_click = canvas_eyedropper_ring.clone();
     let apply_picker_color_to_editor_canvas_click = apply_picker_color_to_editor.clone();
@@ -2528,7 +2590,12 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let text_size_list_click = text_size_list.clone();
     let font_family_list_click = font_family_list.clone();
     let sync_select_inspector_canvas_click = sync_select_inspector.clone();
-    click.connect_pressed(move |_gesture, n_press, x, y| {
+    click.connect_pressed(move |gesture, n_press, x, y| {
+        if space_pan_active_click.get() {
+            gesture.set_state(gtk4::EventSequenceState::Denied);
+            return;
+        }
+
         let t = *transform_click.lock().unwrap();
         let view_point = Point { x, y };
 
@@ -3005,9 +3072,25 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let transform_motion = transform.clone();
     let window_motion = window.downgrade();
     let drawing_area_motion = drawing_area.downgrade();
+    let space_pan_active_motion = space_pan_active.clone();
+    let space_pan_dragging_motion = space_pan_dragging.clone();
     motion.connect_motion(move |_, x, y| {
         let t = *transform_motion.lock().unwrap();
         let view_point = Point { x, y };
+
+        if space_pan_active_motion.get() {
+            if let Some(window) = window_motion.upgrade() {
+                set_window_cursor_name(
+                    &window,
+                    Some(if space_pan_dragging_motion.get() {
+                        "grabbing"
+                    } else {
+                        "grab"
+                    }),
+                );
+            }
+            return;
+        }
 
         if eyedropper_mode_motion.get() {
             if !t.contains_view(view_point) {
@@ -3298,6 +3381,8 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
     let zoom_level_keys = zoom_level.clone();
     let update_canvas_content_size_keys = update_canvas_content_size.clone();
     let zoom_popup_keys = zoom_popup.clone();
+    let space_pan_active_keys = space_pan_active.clone();
+    let space_pan_dragging_keys = space_pan_dragging.clone();
 
     key_controller.connect_key_pressed(move |_, key, _, modifiers| {
         if key == gdk::Key::Escape && eyedropper_mode_keys.get() {
@@ -3362,6 +3447,21 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
                     return glib::Propagation::Stop;
                 }
             }
+        }
+
+        if key == gdk::Key::space && !eyedropper_mode_keys.get() {
+            space_pan_active_keys.set(true);
+            if let Some(window) = window_keys.upgrade() {
+                set_window_cursor_name(
+                    &window,
+                    Some(if space_pan_dragging_keys.get() {
+                        "grabbing"
+                    } else {
+                        "grab"
+                    }),
+                );
+            }
+            return glib::Propagation::Stop;
         }
 
         if ctrl && (pressed == Some('z') || pressed == Some('Z')) {
@@ -3460,6 +3560,29 @@ pub(super) fn wire_editor_events(ctx: EventContext) {
 
         glib::Propagation::Proceed
     });
+    let space_pan_active_released = space_pan_active.clone();
+    let space_pan_dragging_released = space_pan_dragging.clone();
+    let eyedropper_mode_released = eyedropper_mode.clone();
+    let window_released = window.downgrade();
+    key_controller.connect_key_released(move |_, key, _, _| {
+        if key != gdk::Key::space {
+            return;
+        }
+
+        space_pan_active_released.set(false);
+        if !space_pan_dragging_released.get() {
+            if let Some(window) = window_released.upgrade() {
+                set_window_cursor_name(
+                    &window,
+                    if eyedropper_mode_released.get() {
+                        Some("crosshair")
+                    } else {
+                        None
+                    },
+                );
+            }
+        }
+    });
     window.add_controller(key_controller);
 
     let app_weak = app.downgrade();
@@ -3509,8 +3632,23 @@ mod tests {
                 && production_source.contains("zoom_popup_in.set_visible(false);")
                 && production_source.contains("update_canvas_content_size();")
                 && production_source.contains("drawing_area.queue_draw();")
-                && production_source.contains("scroll_controller.connect_scroll(move |_, _dx, dy| {"),
-            "Footer zoom actions should open the popover, update the zoom state, refresh canvas layout, and support wheel zoom",
+                && production_source.contains("scroll_controller.connect_scroll(move |controller, _dx, dy| {")
+                && production_source.contains("gdk::ModifierType::CONTROL_MASK"),
+            "Footer zoom actions should open the popover, update the zoom state, refresh canvas layout, and support Ctrl-wheel zoom",
+        );
+    }
+
+    #[test]
+    fn canvas_scrolls_normally_and_space_enables_primary_button_panning() {
+        let source = include_str!("events.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("return glib::Propagation::Proceed;")
+                && production_source.contains("if space_pan_active_drag_begin.get() {")
+                && production_source.contains("space_pan_dragging_begin.set(true);")
+                && production_source.contains("if key == gdk::Key::space && !eyedropper_mode_keys.get()")
+                && production_source.contains("Some(\"grab\")"),
+            "normal scrolling should reach the canvas scroller while space temporarily enables hand panning"
         );
     }
 

--- a/src/capture/editor/window/events.rs
+++ b/src/capture/editor/window/events.rs
@@ -3664,7 +3664,8 @@ mod tests {
                 && production_source.contains("zoom_popup_in.set_visible(false);")
                 && production_source.contains("update_canvas_content_size();")
                 && production_source.contains("drawing_area.queue_draw();")
-                && production_source.contains("scroll_controller.connect_scroll(move |controller, _dx, dy| {")
+                && production_source.contains("scroll_controller.connect_scroll(move |controller, dx, dy| {")
+                && production_source.contains("let delta = if dy != 0.0 { dy } else { dx };")
                 && production_source.contains("gdk::ModifierType::CONTROL_MASK"),
             "Footer zoom actions should open the popover, update the zoom state, refresh canvas layout, and support Ctrl-wheel zoom",
         );

--- a/src/capture/editor/window/footer.rs
+++ b/src/capture/editor/window/footer.rs
@@ -1,4 +1,4 @@
-use gtk4::{gdk, prelude::*, Box as GtkBox, Button, Label, Orientation};
+use gtk4::{prelude::*, Box as GtkBox, Button, Label, Orientation};
 
 use super::super::ui_support::footer_icon_button;
 
@@ -45,131 +45,6 @@ fn build_zoom_row(label: &str, shortcut: &str) -> (Button, GtkBox) {
         .build();
 
     (btn, row)
-}
-
-fn build_mouse_hints() -> GtkBox {
-    let container = GtkBox::new(Orientation::Horizontal, 0);
-    container.add_css_class("editor-footer-zoom-mouse-hints");
-    container.set_halign(gtk4::Align::Center);
-
-    let left_text = Label::new(Some("Zoom with\nthe scroll\nwheel"));
-    left_text.set_justify(gtk4::Justification::Right);
-    left_text.add_css_class("editor-footer-zoom-mouse-hint-text");
-
-    let drawing = gtk4::DrawingArea::new();
-    drawing.add_css_class("editor-footer-zoom-mouse-drawing");
-    drawing.set_content_width(60);
-    drawing.set_content_height(60);
-    drawing.set_draw_func(move |widget, cr, width, height| {
-        let w = f64::from(width);
-        let h = f64::from(height);
-        let fg = widget.style_context().color();
-        let accent = widget
-            .style_context()
-            .lookup_color("accent_color")
-            .unwrap_or_else(|| gdk::RGBA::new(0.69, 0.36, 0.22, 1.0));
-        let fg_r = fg.red() as f64;
-        let fg_g = fg.green() as f64;
-        let fg_b = fg.blue() as f64;
-        let accent_r = accent.red() as f64;
-        let accent_g = accent.green() as f64;
-        let accent_b = accent.blue() as f64;
-
-        // Draw mouse body (simple rounded rect)
-        let mouse_w = 24.0;
-        let mouse_h = 40.0;
-        let mouse_x = (w - mouse_w) / 2.0;
-        let mouse_y = h - mouse_h - 5.0;
-        let radius = 10.0;
-
-        cr.set_source_rgba(fg_r, fg_g, fg_b, 0.24);
-        cr.set_line_width(1.0);
-        cr.new_sub_path();
-        cr.arc(
-            mouse_x + radius,
-            mouse_y + radius,
-            radius,
-            180.0 * std::f64::consts::PI / 180.0,
-            270.0 * std::f64::consts::PI / 180.0,
-        );
-        cr.arc(
-            mouse_x + mouse_w - radius,
-            mouse_y + radius,
-            radius,
-            270.0 * std::f64::consts::PI / 180.0,
-            360.0 * std::f64::consts::PI / 180.0,
-        );
-        cr.line_to(mouse_x + mouse_w, mouse_y + mouse_h);
-        cr.line_to(mouse_x, mouse_y + mouse_h);
-        cr.close_path();
-        let _ = cr.stroke();
-
-        // Draw middle line for buttons
-        cr.move_to(mouse_x + mouse_w / 2.0, mouse_y);
-        cr.line_to(mouse_x + mouse_w / 2.0, mouse_y + 15.0);
-        let _ = cr.stroke();
-
-        // Draw scroll wheel (highlighted blue)
-        let wheel_w = 4.0;
-        let wheel_h = 10.0;
-        let wheel_x = (w - wheel_w) / 2.0;
-        let wheel_y = mouse_y + 8.0;
-        cr.set_source_rgba(accent_r, accent_g, accent_b, 0.85);
-        cr.new_sub_path();
-        cr.arc(
-            wheel_x + wheel_w / 2.0,
-            wheel_y + wheel_w / 2.0,
-            wheel_w / 2.0,
-            180.0 * std::f64::consts::PI / 180.0,
-            360.0 * std::f64::consts::PI / 180.0,
-        );
-        cr.arc(
-            wheel_x + wheel_w / 2.0,
-            wheel_y + wheel_h - wheel_w / 2.0,
-            wheel_w / 2.0,
-            0.0,
-            180.0 * std::f64::consts::PI / 180.0,
-        );
-        cr.close_path();
-        let _ = cr.fill();
-
-        // Draw lines pointing to hints
-        cr.set_source_rgba(accent_r, accent_g, accent_b, 0.45);
-        cr.set_line_width(0.8);
-
-        // To scroll wheel
-        cr.move_to(mouse_x - 5.0, wheel_y + wheel_h / 2.0);
-        cr.curve_to(
-            mouse_x - 15.0,
-            wheel_y + wheel_h / 2.0,
-            wheel_x - 5.0,
-            wheel_y + wheel_h / 2.0,
-            wheel_x - 2.0,
-            wheel_y + wheel_h / 2.0,
-        );
-        let _ = cr.stroke();
-
-        // To right button
-        cr.move_to(w - (mouse_x - 5.0), wheel_y + wheel_h / 2.0);
-        cr.curve_to(
-            w - (mouse_x - 15.0),
-            wheel_y + wheel_h / 2.0,
-            wheel_x + wheel_w + 5.0,
-            wheel_y + wheel_h / 2.0,
-            wheel_x + wheel_w + 2.0,
-            wheel_y + wheel_h / 2.0,
-        );
-        let _ = cr.stroke();
-    });
-
-    let right_text = Label::new(Some("Pan with\nthe right\nbutton"));
-    right_text.set_justify(gtk4::Justification::Left);
-    right_text.add_css_class("editor-footer-zoom-mouse-hint-text");
-
-    container.append(&left_text);
-    container.append(&drawing);
-    container.append(&right_text);
-    container
 }
 
 pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> FooterParts {
@@ -221,11 +96,6 @@ pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> Foot
     let sep1 = GtkBox::new(Orientation::Horizontal, 0);
     sep1.add_css_class("editor-footer-zoom-separator");
 
-    let sep2 = GtkBox::new(Orientation::Horizontal, 0);
-    sep2.add_css_class("editor-footer-zoom-separator");
-
-    let mouse_hints = build_mouse_hints();
-
     zoom_list.append(&zoom_in_btn);
     zoom_list.append(&zoom_out_btn);
     zoom_list.append(&fit_to_screen_btn);
@@ -234,8 +104,6 @@ pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> Foot
     zoom_popup.append(&zoom_header);
     zoom_popup.append(&sep1);
     zoom_popup.append(&zoom_list);
-    zoom_popup.append(&sep2);
-    zoom_popup.append(&mouse_hints);
 
     let (copy_btn, _) = footer_icon_button(copy_icon_name, "Copy file URI");
     let (upload_btn, _) = footer_icon_button(upload_icon_name, "Upload to cloud");

--- a/src/capture/editor/window/footer.rs
+++ b/src/capture/editor/window/footer.rs
@@ -3,7 +3,6 @@ use gtk4::{gdk, prelude::*, Box as GtkBox, Button, Label, Orientation};
 use super::super::ui_support::footer_icon_button;
 
 pub(super) struct FooterParts {
-    pub root: GtkBox,
     pub zoom_button: Button,
     pub zoom_label: Label,
     pub zoom_header_label: Label,
@@ -183,6 +182,14 @@ pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> Foot
     zoom_label.add_css_class("editor-footer-zoom-label");
     zoom_button.set_child(Some(&zoom_label));
 
+    let zoom_minus_btn = Button::with_label("-");
+    zoom_minus_btn.add_css_class("editor-floating-zoom-step");
+    zoom_minus_btn.add_css_class("flat");
+
+    let zoom_plus_btn = Button::with_label("+");
+    zoom_plus_btn.add_css_class("editor-floating-zoom-step");
+    zoom_plus_btn.add_css_class("flat");
+
     let zoom_popup = GtkBox::new(Orientation::Vertical, 0);
     zoom_popup.add_css_class("editor-footer-zoom-popup");
     zoom_popup.set_halign(gtk4::Align::Start);
@@ -192,25 +199,15 @@ pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> Foot
     zoom_popup.set_visible(false);
 
     // Header
-    let zoom_header = GtkBox::new(Orientation::Horizontal, 8);
+    let zoom_header = GtkBox::new(Orientation::Horizontal, 0);
     zoom_header.add_css_class("editor-footer-zoom-header");
-
-    let zoom_minus_btn = Button::with_label("-");
-    zoom_minus_btn.add_css_class("editor-footer-zoom-header-btn");
-    zoom_minus_btn.add_css_class("flat");
 
     let zoom_header_label = Label::new(Some("100%"));
     zoom_header_label.set_hexpand(true);
+    zoom_header_label.set_xalign(0.5);
     zoom_header_label.add_css_class("editor-footer-zoom-header-label");
 
-    let zoom_plus_btn = Button::with_label("+");
-    zoom_plus_btn.add_css_class("editor-footer-zoom-header-btn");
-    zoom_plus_btn.add_css_class("orange-btn");
-    zoom_plus_btn.add_css_class("flat");
-
-    zoom_header.append(&zoom_minus_btn);
     zoom_header.append(&zoom_header_label);
-    zoom_header.append(&zoom_plus_btn);
 
     // List of actions
     let zoom_list = GtkBox::new(Orientation::Vertical, 0);
@@ -243,32 +240,13 @@ pub(super) fn build_footer(copy_icon_name: &str, upload_icon_name: &str) -> Foot
     let (copy_btn, _) = footer_icon_button(copy_icon_name, "Copy file URI");
     let (upload_btn, _) = footer_icon_button(upload_icon_name, "Upload to cloud");
 
-    let root = GtkBox::new(Orientation::Horizontal, 0);
-    root.add_css_class("editor-footer");
-
-    let footer_left = GtkBox::new(Orientation::Horizontal, 0);
-    footer_left.set_hexpand(true);
-    footer_left.set_halign(gtk4::Align::Start);
-    footer_left.append(&zoom_button);
-
     let save_btn = Button::with_label("Done");
     save_btn.set_has_frame(false);
     save_btn.add_css_class("editor-done-button");
     save_btn.add_css_class("body");
     save_btn.set_valign(gtk4::Align::Center);
 
-    let footer_right = GtkBox::new(Orientation::Horizontal, 8);
-    footer_right.set_hexpand(true);
-    footer_right.set_halign(gtk4::Align::End);
-    footer_right.append(&copy_btn);
-    footer_right.append(&upload_btn);
-    footer_right.append(&save_btn);
-
-    root.append(&footer_left);
-    root.append(&footer_right);
-
     FooterParts {
-        root,
         zoom_button,
         zoom_label,
         zoom_header_label,

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -27,8 +27,8 @@ use super::render::{
 use super::selection::{action_bounds_with_padding, action_resize_handles};
 use super::state::{apply_effect_actions, render_shadow_layer, EditorState};
 use super::types::{
-    AnnotationAction, ArrowStyle, BackgroundAlignment, BackgroundStyle, CropAspectRatio, DrawColor,
-    EditorError, Point, Rect, Tool, ViewTransform,
+    tool_button_index, AnnotationAction, ArrowStyle, BackgroundAlignment, BackgroundStyle,
+    CropAspectRatio, DrawColor, EditorError, Point, Rect, Tool, ViewTransform,
 };
 
 const MAX_PREVIEW_SHADOW_DIM: u32 = 1200;
@@ -206,8 +206,8 @@ fn selected_action_geometry(action: &AnnotationAction) -> String {
 use super::ui_support::{
     arrow_style_toolbar_icon, install_edge_resize, install_editor_css, install_top_bar_window_drag,
     install_window_drag, prefers_dark_glass_theme, prefers_reduced_transparency,
-    recommended_window_size_with_extra_width, tool_icon_widget, toolbar_icon_size,
-    EDITOR_MIN_WINDOW_WIDTH, EDITOR_TOP_CHROME_HEIGHT,
+    recommended_window_size_with_extra_width, set_active_tool_button, tool_icon_widget,
+    toolbar_icon_size, EDITOR_MIN_WINDOW_WIDTH, EDITOR_TOP_CHROME_HEIGHT,
 };
 
 const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
@@ -3692,8 +3692,8 @@ fn setup_editor_window_full(
         focus_btn.clone(),       // 12 Focus
     ];
 
-    // Set initial active tool button (Background is default)
-    background_btn.add_css_class("active-tool");
+    // Highlight whatever tool preferences restored (Background is only the default).
+    set_active_tool_button(&tool_buttons, tool_button_index(initial_tool));
 
     events::wire_editor_events(events::EventContext {
         app: app.clone(),
@@ -3985,8 +3985,12 @@ mod tests {
         assert!(
             production_source.contains("let initial_tool = state.lock().unwrap().selected_tool;")
                 && production_source.contains("update_toolbar_for_tool(initial_tool);")
-                && !production_source.contains("update_toolbar_for_tool(Tool::Arrow);"),
-            "Editor startup should route the inspector from the selected startup tool instead of forcing Arrow",
+                && production_source.contains(
+                    "set_active_tool_button(&tool_buttons, tool_button_index(initial_tool));",
+                )
+                && !production_source.contains("update_toolbar_for_tool(Tool::Arrow);")
+                && !production_source.contains("background_btn.add_css_class(\"active-tool\");"),
+            "Editor startup should highlight and route the inspector from the restored tool, not hardcode Background/Arrow",
         );
     }
 

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -205,9 +205,9 @@ fn selected_action_geometry(action: &AnnotationAction) -> String {
 
 use super::ui_support::{
     arrow_style_toolbar_icon, install_edge_resize, install_editor_css, install_top_bar_window_drag,
-    prefers_dark_glass_theme, prefers_reduced_transparency,
+    install_window_drag, prefers_dark_glass_theme, prefers_reduced_transparency,
     recommended_window_size_with_extra_width, tool_icon_widget, toolbar_icon_size,
-    EDITOR_MIN_WINDOW_WIDTH,
+    EDITOR_MIN_WINDOW_WIDTH, EDITOR_TOP_CHROME_HEIGHT,
 };
 
 const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
@@ -2014,9 +2014,13 @@ fn setup_editor_window_full(
     sidebar_actions.append(&save_btn);
     inspector.append(&sidebar_actions);
 
+    // Canvas fills the pane (checkerboard). Toolbar + drag strip float on top;
+    // image content is inset below the strip so it never covers the tools.
     let canvas_with_toolbar = Overlay::new();
     canvas_with_toolbar.set_hexpand(true);
     canvas_with_toolbar.set_vexpand(true);
+    canvas.set_hexpand(true);
+    canvas.set_vexpand(true);
     canvas_with_toolbar.set_child(Some(&canvas));
 
     let workspace = GtkBox::new(Orientation::Horizontal, 0);
@@ -2510,16 +2514,29 @@ fn setup_editor_window_full(
     // Keep window-wide transient UI above the editor layout.
     let root_overlay = Overlay::new();
     root_overlay.set_child(Some(&root));
-    let toolbar_overlay = GtkBox::new(Orientation::Horizontal, 0);
-    toolbar_overlay.set_halign(Align::Center);
-    toolbar_overlay.set_valign(Align::Start);
-    toolbar_overlay.set_hexpand(false);
-    toolbar_overlay.set_margin_top(16);
-    toolbar.set_halign(Align::Start);
-    toolbar.set_valign(Align::Start);
+
+    // Transparent full-width strip over the checkerboard: drag the window + host toolbar.
+    let top_chrome = GtkBox::new(Orientation::Horizontal, 0);
+    top_chrome.add_css_class("editor-top-chrome");
+    top_chrome.set_halign(Align::Fill);
+    top_chrome.set_valign(Align::Start);
+    top_chrome.set_hexpand(true);
+    top_chrome.set_vexpand(false);
+    top_chrome.set_size_request(-1, EDITOR_TOP_CHROME_HEIGHT);
+    top_chrome.set_can_target(true);
+
+    let top_chrome_left = GtkBox::new(Orientation::Horizontal, 0);
+    top_chrome_left.set_hexpand(true);
+    let top_chrome_right = GtkBox::new(Orientation::Horizontal, 0);
+    top_chrome_right.set_hexpand(true);
+
+    toolbar.set_halign(Align::Center);
+    toolbar.set_valign(Align::Center);
     toolbar.set_hexpand(false);
-    toolbar_overlay.append(&toolbar);
-    canvas_with_toolbar.add_overlay(&toolbar_overlay);
+    top_chrome.append(&top_chrome_left);
+    top_chrome.append(&toolbar);
+    top_chrome.append(&top_chrome_right);
+    canvas_with_toolbar.add_overlay(&top_chrome);
 
     let zoom_control = GtkBox::new(Orientation::Horizontal, 0);
     zoom_control.add_css_class("editor-floating-zoom");
@@ -2658,7 +2675,8 @@ fn setup_editor_window_full(
 
     window.set_child(Some(&root_overlay));
 
-    // The full top bar moves the window; interactive controls remain excluded.
+    // Full-width canvas chrome + top inspector band move the window; tools/canvas stay interactive.
+    install_window_drag(&top_chrome, &window);
     install_top_bar_window_drag(&root_overlay, &window);
     install_edge_resize(&root_overlay, &window);
 
@@ -2715,8 +2733,11 @@ fn setup_editor_window_full(
 
             let scroller_width = canvas_scroller.allocated_width().max(1) as f64;
             let scroller_height = canvas_scroller.allocated_height().max(1) as f64;
+            // Keep fit-to-view math below the floating toolbar strip.
+            let top_inset = canvas_padding + EDITOR_TOP_CHROME_HEIGHT;
             let available_width = (scroller_width - (canvas_padding * 2 + 2) as f64).max(1.0);
-            let available_height = (scroller_height - (canvas_padding * 2 + 2) as f64).max(1.0);
+            let available_height =
+                (scroller_height - (top_inset + canvas_padding + 2) as f64).max(1.0);
 
             // Use the minimum of width and height to maintain aspect ratio and prevent asymmetric growth
             let available_size = available_width.min(available_height);
@@ -2745,8 +2766,10 @@ fn setup_editor_window_full(
                 + canvas_padding * 2
                 + overflow_left.round() as i32
                 + overflow_right.round() as i32;
+            // Extra top inset so zoomed content cannot sit under the toolbar.
             let canvas_h = fitted_h
-                + canvas_padding * 2
+                + top_inset
+                + canvas_padding
                 + overflow_top.round() as i32
                 + overflow_bottom.round() as i32;
 
@@ -2804,8 +2827,10 @@ fn setup_editor_window_full(
                 // same overflow values without duplicating the full layout calculation.
                 let virtual_w = img_w as f64;
                 let virtual_h = img_h as f64;
+                let top_inset = canvas_padding + EDITOR_TOP_CHROME_HEIGHT;
                 let available_w = (width as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
-                let available_h = (height as f64 - (canvas_padding * 2 + 2) as f64).max(1.0);
+                let available_h =
+                    (height as f64 - (top_inset + canvas_padding + 2) as f64).max(1.0);
 
                 let available_size = available_w.min(available_h);
                 let layout_scale = (available_size / virtual_w.min(virtual_h)).min(1.0_f64);
@@ -3109,7 +3134,10 @@ fn setup_editor_window_full(
             background_layout = Some(layout);
         }
 
-        let base_view_width = (width as f64 - canvas_padding_draw * 2.0).max(1.0);
+        let toolbar_clearance = f64::from(EDITOR_TOP_CHROME_HEIGHT);
+        let top_pad = canvas_padding_draw + toolbar_clearance;
+        let side_pad = canvas_padding_draw;
+        let base_view_width = (width as f64 - side_pad * 2.0).max(1.0);
         let base_scale = (base_view_width / virtual_w).min(1.0);
         let (overflow_left, overflow_top, overflow_right, overflow_bottom) = if has_background {
             (0.0, 0.0, 0.0, 0.0)
@@ -3124,9 +3152,13 @@ fn setup_editor_window_full(
         };
 
         let view_width =
-            (width as f64 - canvas_padding_draw * 2.0 - overflow_left - overflow_right).max(1.0);
-        let view_height =
-            (height as f64 - canvas_padding_draw * 2.0 - overflow_top - overflow_bottom).max(1.0);
+            (width as f64 - side_pad * 2.0 - overflow_left - overflow_right).max(1.0);
+        let view_height = (height as f64
+            - top_pad
+            - side_pad
+            - overflow_top
+            - overflow_bottom)
+            .max(1.0);
 
         let scale = (view_width / virtual_w)
             .min(view_height / virtual_h)
@@ -3134,17 +3166,18 @@ fn setup_editor_window_full(
             * zoom_level_draw.get().max(0.1_f64);
         let draw_width = virtual_w * scale;
         let draw_height = virtual_h * scale;
+        // Center within the area below the toolbar strip; top_pad keeps image clear of tools.
         let placement = canvas::initial_viewport_offset(
             draw_width,
             draw_height,
             view_width,
             view_height,
-            canvas_padding_draw,
+            0.0,
         );
         let mut t = ViewTransform {
             scale,
-            offset_x: placement.offset_x + overflow_left,
-            offset_y: placement.offset_y + overflow_top,
+            offset_x: side_pad + placement.offset_x + overflow_left,
+            offset_y: top_pad + placement.offset_y + overflow_top,
             image_width: virtual_w,
             image_height: virtual_h,
         };
@@ -3885,9 +3918,13 @@ mod tests {
         let source = include_str!("mod.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
-            production_source.contains("install_top_bar_window_drag(&root_overlay, &window);")
+            production_source.contains("install_window_drag(&top_chrome, &window);")
+                && production_source.contains("install_top_bar_window_drag(&root_overlay, &window);")
+                && production_source.contains("editor-top-chrome")
+                && production_source.contains("canvas_with_toolbar.add_overlay(&top_chrome);")
+                && production_source.contains("EDITOR_TOP_CHROME_HEIGHT")
                 && !production_source.contains("install_window_drag(&toolbar, &window);"),
-            "the editor should drag from the full top bar, not only its narrow toolbar"
+            "toolbar drag strip should float over the checkerboard canvas, not replace it"
         );
     }
 

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -3151,14 +3151,9 @@ fn setup_editor_window_full(
             )
         };
 
-        let view_width =
-            (width as f64 - side_pad * 2.0 - overflow_left - overflow_right).max(1.0);
-        let view_height = (height as f64
-            - top_pad
-            - side_pad
-            - overflow_top
-            - overflow_bottom)
-            .max(1.0);
+        let view_width = (width as f64 - side_pad * 2.0 - overflow_left - overflow_right).max(1.0);
+        let view_height =
+            (height as f64 - top_pad - side_pad - overflow_top - overflow_bottom).max(1.0);
 
         let scale = (view_width / virtual_w)
             .min(view_height / virtual_h)
@@ -3167,13 +3162,8 @@ fn setup_editor_window_full(
         let draw_width = virtual_w * scale;
         let draw_height = virtual_h * scale;
         // Center within the area below the toolbar strip; top_pad keeps image clear of tools.
-        let placement = canvas::initial_viewport_offset(
-            draw_width,
-            draw_height,
-            view_width,
-            view_height,
-            0.0,
-        );
+        let placement =
+            canvas::initial_viewport_offset(draw_width, draw_height, view_width, view_height, 0.0);
         let mut t = ViewTransform {
             scale,
             offset_x: side_pad + placement.offset_x + overflow_left,
@@ -3919,7 +3909,8 @@ mod tests {
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
             production_source.contains("install_window_drag(&top_chrome, &window);")
-                && production_source.contains("install_top_bar_window_drag(&root_overlay, &window);")
+                && production_source
+                    .contains("install_top_bar_window_drag(&root_overlay, &window);")
                 && production_source.contains("editor-top-chrome")
                 && production_source.contains("canvas_with_toolbar.add_overlay(&top_chrome);")
                 && production_source.contains("EDITOR_TOP_CHROME_HEIGHT")

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -818,6 +818,7 @@ fn setup_editor_window_full(
 
     let root = GtkBox::new(Orientation::Vertical, 0);
     root.add_css_class("editor-root");
+    root.set_overflow(gtk4::Overflow::Hidden);
 
     let prefers_dark = prefers_dark_glass_theme();
     let reduced_transparency = prefers_reduced_transparency();
@@ -957,11 +958,15 @@ fn setup_editor_window_full(
         &sep_1,
         &sep_2,
     );
-    // Left-align tools: mount the center_group as the start widget so there's no
-    // empty space on the left of the toolbar.
-    toolbar.set_start_widget(Some(&center_group));
+    toolbar.append(&center_group);
 
-    let toolbar_right_parts = toolbar::build_toolbar_right_controls(
+    let toolbar::ToolbarRightParts {
+        root: sidebar_utility_controls,
+        history_group,
+        undo_btn,
+        redo_btn,
+        delete_selected_btn,
+    } = toolbar::build_toolbar_right_controls(
         &color_status,
         icon_names::custom::EDIT_UNDO_SYMBOLIC,
         icon_names::custom::EDIT_UNDO_RTL_SYMBOLIC,
@@ -970,10 +975,6 @@ fn setup_editor_window_full(
         &traffic_zoom,
         &traffic_close,
     );
-    let undo_btn = toolbar_right_parts.undo_btn;
-    let redo_btn = toolbar_right_parts.redo_btn;
-    let delete_selected_btn = toolbar_right_parts.delete_selected_btn;
-    toolbar.set_end_widget(Some(&toolbar_right_parts.root));
 
     let crop_ratio_list = GtkBox::new(Orientation::Vertical, 0);
     for crop_type in CropAspectRatio::ALL {
@@ -1355,6 +1356,8 @@ fn setup_editor_window_full(
     let copy_btn = footer_parts.copy_btn;
     let upload_btn = footer_parts.upload_btn;
     let save_btn = footer_parts.save_btn;
+    copy_btn.add_css_class("editor-sidebar-action-button");
+    upload_btn.add_css_class("editor-sidebar-action-button");
     if empty_drop_zone {
         copy_btn.set_sensitive(false);
         upload_btn.set_sensitive(false);
@@ -1377,8 +1380,8 @@ fn setup_editor_window_full(
         &GtkBox::new(Orientation::Vertical, 0), // Placeholder, will be replaced
         canvas::EYEDROPPER_LOUPE_SIZE,
     );
-    // Note: zoom_popup is NOT added to canvas_overlay here - it will be added
-    // to a root-level overlay later to stay fixed during zoom/scroll.
+    // The zoom controls are added to the canvas pane later so they remain fixed
+    // while the image scrolls and scales.
 
     // Background style cache
     let cached_background_surface =
@@ -1963,6 +1966,7 @@ fn setup_editor_window_full(
     inspector.set_width_request(BACKGROUND_SIDEBAR_WIDTH);
     inspector.set_hexpand(false);
     inspector.set_vexpand(true);
+    inspector.append(&sidebar_utility_controls);
     inspector.append(&inspector_tabs);
 
     let inspector_stack = Stack::new();
@@ -1998,10 +2002,25 @@ fn setup_editor_window_full(
     inspector_stack.set_visible_child_name("placeholder");
     inspector.append(&inspector_stack);
 
+    let sidebar_actions = GtkBox::new(Orientation::Horizontal, 8);
+    sidebar_actions.add_css_class("editor-sidebar-actions");
+    let sidebar_action_spacer = GtkBox::new(Orientation::Horizontal, 0);
+    sidebar_action_spacer.set_hexpand(true);
+    sidebar_actions.append(&copy_btn);
+    sidebar_actions.append(&upload_btn);
+    sidebar_actions.append(&sidebar_action_spacer);
+    sidebar_actions.append(&save_btn);
+    inspector.append(&sidebar_actions);
+
+    let canvas_with_toolbar = Overlay::new();
+    canvas_with_toolbar.set_hexpand(true);
+    canvas_with_toolbar.set_vexpand(true);
+    canvas_with_toolbar.set_child(Some(&canvas));
+
     let workspace = GtkBox::new(Orientation::Horizontal, 0);
     workspace.set_hexpand(true);
     workspace.set_vexpand(true);
-    workspace.append(&canvas);
+    workspace.append(&canvas_with_toolbar);
     workspace.append(&inspector);
 
     *drawing_area_placeholder.borrow_mut() = Some(drawing_area.downgrade());
@@ -2484,15 +2503,42 @@ fn setup_editor_window_full(
         }
     });
 
-    root.append(&toolbar);
     root.append(&workspace);
-    root.append(&footer_parts.root);
 
-    // Wrap root in an overlay so zoom_popup can be positioned on top
-    // without being affected by canvas zoom/scroll transformations
+    // Keep window-wide transient UI above the editor layout.
     let root_overlay = Overlay::new();
     root_overlay.set_child(Some(&root));
-    root_overlay.add_overlay(&zoom_popup);
+    let toolbar_overlay = GtkBox::new(Orientation::Horizontal, 0);
+    toolbar_overlay.set_halign(Align::Center);
+    toolbar_overlay.set_valign(Align::Start);
+    toolbar_overlay.set_hexpand(false);
+    toolbar_overlay.set_margin_top(16);
+    toolbar.set_halign(Align::Start);
+    toolbar.set_valign(Align::Start);
+    toolbar.set_hexpand(false);
+    toolbar_overlay.append(&toolbar);
+    canvas_with_toolbar.add_overlay(&toolbar_overlay);
+
+    let zoom_control = GtkBox::new(Orientation::Horizontal, 0);
+    zoom_control.add_css_class("editor-floating-zoom");
+    zoom_control.set_halign(Align::Start);
+    zoom_control.set_valign(Align::End);
+    zoom_control.set_margin_start(16);
+    zoom_control.set_margin_bottom(16);
+    zoom_control.append(&zoom_minus_btn);
+    zoom_control.append(&zoom_button);
+    zoom_control.append(&zoom_plus_btn);
+    canvas_with_toolbar.add_overlay(&zoom_control);
+
+    let history_control = GtkBox::new(Orientation::Horizontal, 0);
+    history_control.add_css_class("editor-floating-history");
+    history_control.set_halign(Align::End);
+    history_control.set_valign(Align::End);
+    history_control.set_margin_end(16);
+    history_control.set_margin_bottom(16);
+    history_control.append(&history_group);
+    canvas_with_toolbar.add_overlay(&history_control);
+    canvas_with_toolbar.add_overlay(&zoom_popup);
 
     if empty_drop_zone {
         // Reuse the video editor's button / banner styles so the empty
@@ -2528,8 +2574,8 @@ fn setup_editor_window_full(
         drop_center.append(&drop_hint);
         drop_center.append(&open_btn);
 
-        // Centre the drop zone over the canvas itself.
-        canvas_overlay.add_overlay(&drop_center);
+        // Keep the empty state centered in the canvas pane, excluding the inspector.
+        canvas_with_toolbar.add_overlay(&drop_center);
 
         // Loading banner (same as the video editor's "Loading video…").
         let loading_box = GtkBox::new(Orientation::Horizontal, 8);

--- a/src/capture/editor/window/mod.rs
+++ b/src/capture/editor/window/mod.rs
@@ -204,9 +204,10 @@ fn selected_action_geometry(action: &AnnotationAction) -> String {
 }
 
 use super::ui_support::{
-    arrow_style_toolbar_icon, install_edge_resize, install_editor_css, install_window_drag,
+    arrow_style_toolbar_icon, install_edge_resize, install_editor_css, install_top_bar_window_drag,
     prefers_dark_glass_theme, prefers_reduced_transparency,
     recommended_window_size_with_extra_width, tool_icon_widget, toolbar_icon_size,
+    EDITOR_MIN_WINDOW_WIDTH,
 };
 
 const TEXT_SIZE_OPTIONS: [i32; 12] = [12, 14, 16, 18, 20, 24, 28, 32, 36, 48, 64, 72];
@@ -815,6 +816,7 @@ fn setup_editor_window_full(
             .build()
     };
     window.add_css_class("editor-window");
+    window.set_size_request(EDITOR_MIN_WINDOW_WIDTH, -1);
 
     let root = GtkBox::new(Orientation::Vertical, 0);
     root.add_css_class("editor-root");
@@ -2656,8 +2658,8 @@ fn setup_editor_window_full(
 
     window.set_child(Some(&root_overlay));
 
-    // Enable window drag from toolbar (empty areas only) and edge resize
-    install_window_drag(&toolbar, &window);
+    // The full top bar moves the window; interactive controls remain excluded.
+    install_top_bar_window_drag(&root_overlay, &window);
     install_edge_resize(&root_overlay, &window);
 
     let update_canvas_content_size: Rc<dyn Fn()> = Rc::new({
@@ -3876,6 +3878,27 @@ mod tests {
         let source = include_str!("mod.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(production_source.contains("editor-right-inspector"));
+    }
+
+    #[test]
+    fn editor_uses_full_top_bar_for_window_dragging() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("install_top_bar_window_drag(&root_overlay, &window);")
+                && !production_source.contains("install_window_drag(&toolbar, &window);"),
+            "the editor should drag from the full top bar, not only its narrow toolbar"
+        );
+    }
+
+    #[test]
+    fn editor_enforces_the_toolbar_safe_minimum_width() {
+        let source = include_str!("mod.rs");
+        let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
+        assert!(
+            production_source.contains("window.set_size_request(EDITOR_MIN_WINDOW_WIDTH, -1);"),
+            "the editor window must not resize narrower than its toolbar-safe width"
+        );
     }
 
     #[test]

--- a/src/capture/editor/window/toolbar.rs
+++ b/src/capture/editor/window/toolbar.rs
@@ -1,6 +1,6 @@
 use gtk4::{
-    prelude::*, Align, Box as GtkBox, Button, CenterBox, Entry, Image, Label, Orientation, Popover,
-    Scale, Stack,
+    prelude::*, Align, Box as GtkBox, Button, Entry, Image, Label, Orientation, Popover, Scale,
+    Stack,
 };
 use std::rc::Rc;
 
@@ -15,7 +15,7 @@ use super::super::{
 use super::icon_names;
 
 pub(super) struct ToolbarBaseParts {
-    pub root: CenterBox,
+    pub root: GtkBox,
     pub traffic_close: Button,
     pub traffic_minimize: Button,
     pub traffic_zoom: Button,
@@ -61,6 +61,7 @@ pub(super) struct ToolbarBaseIconNames<'a> {
 
 pub(super) struct ToolbarRightParts {
     pub root: GtkBox,
+    pub history_group: GtkBox,
     pub undo_btn: Button,
     pub redo_btn: Button,
     pub delete_selected_btn: Button,
@@ -125,7 +126,7 @@ pub(super) struct ToolbarModeParts {
 }
 
 pub(super) fn build_toolbar_base(icon_names: ToolbarBaseIconNames<'_>) -> ToolbarBaseParts {
-    let root = CenterBox::new();
+    let root = GtkBox::new(Orientation::Horizontal, 0);
     root.add_css_class("editor-toolbar");
 
     // Window controls on the right (created here, placed in right controls)
@@ -149,10 +150,6 @@ pub(super) fn build_toolbar_base(icon_names: ToolbarBaseIconNames<'_>) -> Toolba
     let crop_btn = icon_tool_button(icon_names.crop, "Crop");
     let background_btn = icon_tool_button(icon_names::custom::IMAGE_ALT_SYMBOLIC, "Background");
     let draw_btn = icon_tool_button(icon_names.draw, "Pen");
-
-    let left_group = GtkBox::new(Orientation::Horizontal, 0);
-    left_group.add_css_class("editor-toolbar-left");
-    root.set_start_widget(Some(&left_group));
 
     let arrow_btn = icon_tool_button(icon_names.arrow, "Arrow");
     let line_btn = icon_tool_button(icon_names.line, "Line");
@@ -992,27 +989,27 @@ pub(super) fn build_toolbar_right_controls(
     history_group.append(&redo_btn);
     history_group.append(&delete_selected_btn);
 
-    let right_tools = GtkBox::new(Orientation::Horizontal, 12);
-    right_tools.add_css_class("editor-toolbar-right-tools");
-    right_tools.append(&history_group);
-    right_tools.append(color_status);
-
     let wm_controls = GtkBox::new(Orientation::Horizontal, 6);
     wm_controls.add_css_class("editor-toolbar-wm-controls");
     wm_controls.set_valign(Align::Center);
-    wm_controls.set_margin_start(8);
-    wm_controls.set_margin_end(2);
+    wm_controls.set_halign(Align::End);
     wm_controls.append(traffic_minimize);
     wm_controls.append(traffic_zoom);
     wm_controls.append(traffic_close);
 
-    let root = GtkBox::new(Orientation::Horizontal, 0);
+    let root = GtkBox::new(Orientation::Horizontal, 8);
     root.add_css_class("editor-toolbar-right");
-    root.append(&right_tools);
+    root.add_css_class("editor-sidebar-utility-controls");
+    color_status.set_size_request(-1, 24);
+    root.append(color_status);
+    let spacer = GtkBox::new(Orientation::Horizontal, 0);
+    spacer.set_hexpand(true);
+    root.append(&spacer);
     root.append(&wm_controls);
 
     ToolbarRightParts {
         root,
+        history_group,
         undo_btn,
         redo_btn,
         delete_selected_btn,
@@ -1185,15 +1182,15 @@ mod tests {
     }
 
     #[test]
-    fn toolbar_right_controls_contain_history_and_color_status() {
+    fn toolbar_right_controls_split_history_from_sidebar_utilities() {
         let source = include_str!("toolbar.rs");
         let production_source = source.split("#[cfg(test)]").next().unwrap_or(source);
         assert!(
             production_source.contains(
                 "pub(super) fn build_toolbar_right_controls(\n    color_status: &GtkBox,"
-            ) && production_source.contains("right_tools.append(color_status);")
-                && production_source.contains("right_tools.append(&history_group);"),
-            "Toolbar right controls should contain history group and color status",
+            ) && production_source.contains("root.append(color_status);")
+                && production_source.contains("history_group,"),
+            "Sidebar utilities should retain color status while history is returned for canvas placement",
         );
     }
 

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -460,46 +460,6 @@ pub async fn run_daemon() -> anyhow::Result<()> {
     run_daemon_inner(None).await
 }
 
-/// Ensure ydotoold daemon is running for scroll capture on Wayland.
-/// This is called at startup to ensure scroll functionality works.
-fn ensure_ydotoold_running() {
-    use std::process::Command;
-
-    // Check if ydotoold is already running
-    let output = Command::new("pgrep").arg("-x").arg("ydotoold").output();
-
-    if let Ok(output) = output {
-        if output.status.success() {
-            eprintln!("[daemon] ydotoold is already running");
-            return;
-        }
-    }
-
-    // Try to start ydotoold daemon
-    eprintln!("[daemon] Starting ydotoold daemon for scroll capture...");
-
-    let result = Command::new("ydotoold")
-        .arg("--socket-path=/tmp/.ydotool_socket")
-        .arg("--socket-own=1000:1000")
-        .spawn();
-
-    match result {
-        Ok(_) => {
-            // Give it a moment to start
-            std::thread::sleep(std::time::Duration::from_millis(500));
-            eprintln!("[daemon] ydotoold started successfully");
-        }
-        Err(e) => {
-            eprintln!("[daemon] Warning: Could not start ydotoold: {}", e);
-            eprintln!("[daemon] Scroll capture may not work on Wayland without ydotoold");
-        }
-    }
-}
-
-fn should_autostart_ydotoold() -> bool {
-    false
-}
-
 fn should_quit_on_sigint(recording_active: bool) -> bool {
     !recording_active
 }
@@ -513,10 +473,6 @@ async fn run_daemon_inner(gtk_tx: Option<std::sync::mpsc::Sender<GtkWork>>) -> a
 
     // Pre-warm apexshot-capture so the first hotkey doesn't pay Qt cold start.
     ensure_warm_capture_helper();
-
-    if should_autostart_ydotoold() {
-        ensure_ydotoold_running();
-    }
 
     // ── SINGLE-INSTANCE CHECK ─────────────────────────────────────────────────
     // Try to register D-Bus name BEFORE any other initialization.
@@ -3007,14 +2963,9 @@ async fn handle_record_area(_tx: std::sync::mpsc::Sender<DaemonAction>) {
 mod tests {
     use super::{
         clipboard_missing_image_notification, last_capture_target, restore_recently_closed_target,
-        should_autostart_ydotoold, should_quit_on_sigint, should_show_preview_after_toggle,
+        should_quit_on_sigint, should_show_preview_after_toggle,
     };
     use std::{path::Path, time::Duration};
-
-    #[test]
-    fn daemon_does_not_autostart_ydotoold_by_default() {
-        assert!(!should_autostart_ydotoold());
-    }
 
     #[test]
     fn audio_monitor_idle_detection() {

--- a/src/settings/after_capture.rs
+++ b/src/settings/after_capture.rs
@@ -1,5 +1,5 @@
 use crate::config::AppConfig;
-use gtk4::{prelude::*, Align, Box as GtkBox, CheckButton, Grid, Label, Orientation, Separator};
+use gtk4::{prelude::*, Align, Box as GtkBox, CheckButton, Grid, Label, Orientation};
 
 #[allow(dead_code)]
 pub struct AfterCaptureWidgets {
@@ -69,10 +69,6 @@ pub fn build_after_capture_section(config: &AppConfig) -> AfterCaptureWidgets {
     after_capture_header_row.attach(&recording_header_cell, 1, 0, 1, 1);
     after_capture_header_row.attach(&action_header, 2, 0, 1, 1);
     after_capture_table.append(&after_capture_header_row);
-
-    let table_header_separator = Separator::new(Orientation::Horizontal);
-    table_header_separator.set_hexpand(true);
-    after_capture_table.append(&table_header_separator);
 
     let screenshot_after_capture_rows = [
         (

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -2,7 +2,7 @@ use crate::config::load_config;
 use gtk4::{
     prelude::*, Align, Application, ApplicationWindow, Box as GtkBox, Button, FileChooserAction,
     FileChooserNative, Image, Label, Orientation, Overlay as GtkOverlay, ResponseType,
-    ScrolledWindow, Separator,
+    ScrolledWindow,
 };
 use std::cell::Cell;
 use std::rc::Rc;
@@ -398,11 +398,6 @@ fn build_settings_window(app: &Application) {
     shortcuts::install_shortcut_editors(&shortcuts, &window);
     let quick_access = build_quick_access_section(&config);
 
-    let after_capture_separator = Separator::new(Orientation::Horizontal);
-    after_capture_separator.set_margin_top(8);
-    after_capture_separator.set_margin_bottom(8);
-    after_capture_separator.set_hexpand(true);
-
     let screenshot_export_location_entry_pick = screenshots.export_location_entry.clone();
     let window_weak_picker = window.downgrade();
     screenshots
@@ -457,7 +452,6 @@ fn build_settings_window(app: &Application) {
 
     let general_tab_section = GtkBox::new(Orientation::Vertical, 0);
     general_tab_section.append(&general.section);
-    general_tab_section.append(&after_capture_separator);
     general_tab_section.append(&after_capture.wrapper);
 
     // Add them to stack

--- a/src/settings/shortcuts.rs
+++ b/src/settings/shortcuts.rs
@@ -128,6 +128,7 @@ fn install_shortcut_editor(button: &Button, parent: &ApplicationWindow) {
             .transient_for(&parent)
             .modal(true)
             .title("Set Shortcut")
+            .deletable(false)
             .default_width(400)
             .default_height(290)
             .build();
@@ -155,10 +156,10 @@ fn install_shortcut_editor(button: &Button, parent: &ApplicationWindow) {
         header.append(&cancel_btn);
         header.append(&title);
         header.append(&set_btn);
+        dialog.set_titlebar(Some(&header));
 
         let content = dialog.content_area();
         content.set_spacing(0);
-        content.append(&header);
 
         let body = GtkBox::new(Orientation::Vertical, 16);
         body.set_margin_top(12);

--- a/src/settings/ui_support.rs
+++ b/src/settings/ui_support.rs
@@ -445,11 +445,6 @@ const SETTINGS_CSS: &str = r#"
 
             .settings-table-row {
                 padding: 8px 14px;
-                border-bottom: 1px solid alpha(white, 0.04);
-            }
-
-            .settings-table-row:last-child {
-                border-bottom: none;
             }
 
             .settings-table-row-muted {


### PR DESCRIPTION
## Summary

- Redesigns the image editor chrome: floating zoom and history controls on the canvas, sidebar utility/actions layout, tighter toolbar styling, and a minimum editor window width.
- Improves canvas navigation with Space-to-pan, Ctrl+scroll zoom (including horizontal wheel), and smarter Shift-constrained line/arrow snaps (axis or diagonal).
- Removes the ydotool / ydotoold scroll-capture fallback from the overlay and daemon, and cleans related docs and dead settings separators.

## Test plan

- [ ] Open the image editor after a capture and confirm the new layout (toolbar, floating zoom/history, sidebar actions, Done).
- [ ] Verify zoom controls: +/- buttons, zoom popup presets, and Ctrl+scroll zoom in/out.
- [ ] Hold Space and drag to pan the canvas; release Space and confirm normal tool interaction returns.
- [ ] Draw lines/arrows with Shift held and confirm snaps to horizontal, vertical, and 45° diagonals.
- [ ] Toggle light/dark editor themes and confirm floating controls match the chrome.
- [ ] Confirm scroll capture still works via portal/wtype paths (no ydotool dependency).
- [ ] Spot-check Settings → General / After capture for layout regressions after separator cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/apex-shot/codesmith/apexshot/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788266609&installation_model_id=20563&pr_number=44&repository=apex-shot%2Fapexshot&return_to=https%3A%2F%2Fgithub.com%2Fapex-shot%2Fapexshot%2Fpull%2F44&signature=384b8c6644c16dae8b4dded82aaf65eb0ea73b98305818aaf480880c70bed640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->