### PR TITLE
Fix GNOME fullscreen cursor alignment and Detect zoom boundaries

### DIFF
--- a/gnome-extension/shell-overlay.js
+++ b/gnome-extension/shell-overlay.js
@@ -43,6 +43,15 @@ const DBUS_INTERFACE = `
       <arg type="s" name="kind" direction="out"/>
       <arg type="b" name="valid" direction="out"/>
     </method>
+    <method name="GetMonitorGeometryAt">
+      <arg type="i" name="x" direction="in"/>
+      <arg type="i" name="y" direction="in"/>
+      <arg type="i" name="monitor_x" direction="out"/>
+      <arg type="i" name="monitor_y" direction="out"/>
+      <arg type="i" name="width" direction="out"/>
+      <arg type="i" name="height" direction="out"/>
+      <arg type="b" name="valid" direction="out"/>
+    </method>
   </interface>
 </node>`;
 
@@ -213,6 +222,16 @@ export class ShellOverlayService {
     GetPointerSnapshot() {
         this._readPointer();
         return [this._x, this._y, this._cursorKind, true];
+    }
+
+    GetMonitorGeometryAt(x, y) {
+        const monitors = Main.layoutManager.monitors ?? [];
+        const monitor = monitors.find(item =>
+            x >= item.x && x < item.x + item.width &&
+            y >= item.y && y < item.y + item.height);
+        if (!monitor)
+            return [0, 0, 0, 0, false];
+        return [monitor.x, monitor.y, monitor.width, monitor.height, true];
     }
 
     _setupCursorTracking() {

--- a/src/gnome_shell.rs
+++ b/src/gnome_shell.rs
@@ -625,6 +625,18 @@ pub fn get_pointer_snapshot() -> anyhow::Result<(i32, i32, String, bool)> {
     })
 }
 
+pub fn get_monitor_geometry_at(x: i32, y: i32) -> anyhow::Result<(i32, i32, u32, u32)> {
+    with_shell_overlay_proxy(move |proxy| {
+        let (monitor_x, monitor_y, width, height, valid) = proxy
+            .call::<_, _, (i32, i32, i32, i32, bool)>("GetMonitorGeometryAt", &(x, y))
+            .context("GetMonitorGeometryAt failed")?;
+        if !valid || width <= 0 || height <= 0 {
+            anyhow::bail!("GNOME Shell did not find a monitor at ({x},{y})");
+        }
+        Ok((monitor_x, monitor_y, width as u32, height as u32))
+    })
+}
+
 pub fn print_pointer_debug() -> anyhow::Result<()> {
     if !current_session_supports_gnome_shell_overlay() {
         anyhow::bail!("pointer debug requires GNOME Wayland");

--- a/src/recording/controls.rs
+++ b/src/recording/controls.rs
@@ -62,9 +62,37 @@ struct PointerTrackSession {
     region: CaptureRegion,
 }
 
+fn pointer_capture_region(
+    config: &super::RecordingConfig,
+    fullscreen_monitor: Option<CaptureRegion>,
+) -> CaptureRegion {
+    let configured = CaptureRegion::from_capture(config.x, config.y, config.width, config.height);
+    if configured.is_area() {
+        return configured;
+    }
+
+    fullscreen_monitor.unwrap_or(configured)
+}
+
+fn shell_fullscreen_pointer_region(params: &RecordingControlsParams) -> Option<CaptureRegion> {
+    if !params.is_fullscreen || params.capture_w <= 0 || params.capture_h <= 0 {
+        return None;
+    }
+    let center_x = params.capture_x.saturating_add(params.capture_w / 2);
+    let center_y = params.capture_y.saturating_add(params.capture_h / 2);
+    crate::gnome_shell::get_monitor_geometry_at(center_x, center_y)
+        .map(|(x, y, w, h)| CaptureRegion { x, y, w, h })
+        .map_err(|err| {
+            eprintln!(
+                "[recording] GNOME monitor geometry unavailable; using legacy fullscreen pointer coordinates ({err})"
+            );
+            err
+        })
+        .ok()
+}
+
 impl PointerTrackSession {
-    fn start(config: &super::RecordingConfig) -> Self {
-        let region = CaptureRegion::from_capture(config.x, config.y, config.width, config.height);
+    fn start(config: &super::RecordingConfig, region: CaptureRegion) -> Self {
         if !config.pointer_track {
             return Self {
                 started: false,
@@ -650,7 +678,24 @@ async fn run_recording_with_shell_mask(
 
     super::notify_daemon_event("recording_session_started");
     let final_outcome = loop {
-        let pointer_track = PointerTrackSession::start(&config);
+        let fullscreen_monitor = if config.pointer_track && params.is_fullscreen {
+            let monitor_params = params.clone();
+            match tokio::task::spawn_blocking(move || {
+                shell_fullscreen_pointer_region(&monitor_params)
+            })
+            .await
+            {
+                Ok(region) => region,
+                Err(err) => {
+                    eprintln!("[recording] GNOME monitor lookup failed: {err}");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let pointer_region = pointer_capture_region(&config, fullscreen_monitor);
+        let pointer_track = PointerTrackSession::start(&config, pointer_region);
         let (command_tx, command_rx) = mpsc::unbounded_channel();
         control_server.set_command_sender(command_tx);
         let outcome =
@@ -899,6 +944,31 @@ mod tests {
     }
 
     #[test]
+    fn selected_area_pointer_region_takes_precedence_over_monitor_geometry() {
+        let mut config = super::RecordingConfig::default();
+        config.x = Some(250);
+        config.y = Some(-40);
+        config.width = Some(640);
+        config.height = Some(360);
+        let monitor = CaptureRegion {
+            x: 0,
+            y: -200,
+            w: 1920,
+            h: 1080,
+        };
+
+        assert_eq!(
+            pointer_capture_region(&config, Some(monitor)),
+            CaptureRegion {
+                x: 250,
+                y: -40,
+                w: 640,
+                h: 360,
+            }
+        );
+    }
+
+    #[test]
     fn prepare_overlay_recording_request_maps_video_settings() {
         let request = RecordingRequest {
             x: 10,
@@ -1080,7 +1150,7 @@ mod tests {
     #[test]
     fn prepare_overlay_recording_request_uses_full_monitor_bounds_for_fullscreen_capture() {
         let request = RecordingRequest {
-            x: 0,
+            x: -1920,
             y: 32,
             width: 1920,
             height: 1048,
@@ -1102,7 +1172,7 @@ mod tests {
         assert_eq!(
             prepared.controls_params,
             Some(RecordingControlsParams {
-                capture_x: 0,
+                capture_x: -1920,
                 capture_y: 32,
                 capture_w: 1920,
                 capture_h: 1048,
@@ -1114,6 +1184,16 @@ mod tests {
                 countdown_seconds: 3,
                 session_id: None,
             })
+        );
+        let monitor = CaptureRegion {
+            x: -1920,
+            y: 0,
+            w: 1920,
+            h: 1080,
+        };
+        assert_eq!(
+            pointer_capture_region(&prepared.recording_config, Some(monitor)),
+            monitor
         );
     }
 

--- a/src/recording/editor/model_parts/tests.rs
+++ b/src/recording/editor/model_parts/tests.rs
@@ -874,6 +874,47 @@ fn suggest_zoom_clips_skips_regions_overlapping_existing_zooms() {
 }
 
 #[test]
+fn suggest_zoom_clips_keeps_adjacent_click_sessions() {
+    let mut state = VideoEditState::new(metadata());
+    attach_sidecar_with_clicks(&mut state, &[(3.0, 400.0, 300.0), (4.3, 1500.0, 700.0)]);
+
+    assert_eq!(state.suggest_zoom_clips(), 2);
+    assert_eq!(state.zoom_clips.len(), 2);
+    assert!(state.zoom_clips[0].end <= state.zoom_clips[1].start);
+}
+
+#[test]
+fn suggest_zoom_clips_refits_click_near_trim_boundary() {
+    let mut state = VideoEditState::new(metadata());
+    attach_sidecar_with_clicks(&mut state, &[(5.9, 800.0, 500.0)]);
+    state.set_trim_end(6.0);
+
+    assert_eq!(state.suggest_zoom_clips(), 1);
+    assert!((state.zoom_clips[0].start - 4.6).abs() < 1e-9);
+    assert!((state.zoom_clips[0].end - 6.0).abs() < 1e-9);
+}
+
+#[test]
+fn suggest_zoom_clips_assigns_exact_cut_click_to_following_segment() {
+    let mut state = VideoEditState::new(metadata());
+    attach_sidecar_with_clicks(&mut state, &[(4.0, 800.0, 500.0)]);
+    state.add_cut(4.0);
+
+    assert_eq!(state.suggest_zoom_clips(), 1);
+    assert!((state.zoom_clips[0].start - 4.0).abs() < 1e-9);
+}
+
+#[test]
+fn suggest_zoom_clips_uses_cut_boundary_tolerance() {
+    let mut state = VideoEditState::new(metadata());
+    attach_sidecar_with_clicks(&mut state, &[(4.0 - 5e-10, 800.0, 500.0)]);
+    state.add_cut(4.0);
+
+    assert_eq!(state.suggest_zoom_clips(), 1);
+    assert!((state.zoom_clips[0].start - 4.0).abs() < 1e-9);
+}
+
+#[test]
 fn suggest_zoom_clips_skips_landings_outside_kept_segments() {
     let mut state = VideoEditState::new(metadata());
     attach_sidecar_with_landings(&mut state, &[(3.0, 960.0, 540.0), (8.0, 960.0, 540.0)]);

--- a/src/recording/editor/model_parts/zoom_impl.rs
+++ b/src/recording/editor/model_parts/zoom_impl.rs
@@ -210,15 +210,32 @@ impl VideoEditState {
         let segments = self.ordered_placed_segments();
         let mut added = 0;
         for suggestion in suggestions {
-            let Some(&(composition_start, source_start, source_end)) =
-                segments.iter().find(|&&(_, start, end)| {
-                    suggestion.center_time >= start && suggestion.center_time <= end
+            // At an exact cut both neighboring source ranges contain the
+            // timestamp. Match segment_index_at_source by choosing the range
+            // with the later source start rather than attaching the zoom to
+            // the segment that just ended.
+            let Some(&(composition_start, source_start, source_end)) = segments
+                .iter()
+                .filter(|&&(_, start, end)| {
+                    suggestion.center_time + 1e-9 >= start && suggestion.center_time <= end + 1e-9
                 })
+                .max_by(|a, b| a.1.total_cmp(&b.1))
             else {
                 continue;
             };
-            let start = suggestion.start.max(source_start);
-            let end = suggestion.end.min(source_end);
+            let mut start = suggestion.start.max(source_start);
+            let mut end = suggestion.end.min(source_end);
+            // A valid interaction close to a trim/cut boundary can lose most
+            // of its pre/post-roll. Refit the minimum useful duration inside
+            // the selected segment instead of dropping the detection.
+            if end - start < zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS
+                && source_end - source_start >= zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS
+            {
+                let half = zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS * 0.5;
+                start = (suggestion.center_time - half).max(source_start);
+                end = (start + zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS).min(source_end);
+                start = (end - zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS).max(source_start);
+            }
             if end - start < zoom_suggest::MIN_SUGGESTED_ZOOM_SECONDS {
                 continue;
             }

--- a/src/recording/editor/sidecar.rs
+++ b/src/recording/editor/sidecar.rs
@@ -316,10 +316,11 @@ impl PointerSidecar {
 
     /// Return a pointer frame in the encoded video's pixel coordinate space.
     ///
-    /// Pointer tracking uses the selected area's coordinates, but PipeWire can
-    /// encode that area at a different scale (for example on a HiDPI monitor
-    /// or after an output-size limit). Keeping this conversion next to the
-    /// sidecar ensures the preview and export use the same coordinates.
+    /// Pointer tracking uses global logical Shell coordinates. They are
+    /// translated to the capture rectangle when the sidecar is written, but
+    /// PipeWire can encode that rectangle at a different scale (for example on
+    /// a HiDPI monitor or after an output-size limit). Keeping this conversion
+    /// next to the sidecar ensures the preview and export use the same pixels.
     pub fn presented_in_video_at(
         &self,
         t: f64,
@@ -623,6 +624,41 @@ mod tests {
 
         let ripples = sidecar.click_ripples_in_video_at(0.0, 0.32, 1920.0, 1080.0);
         assert_eq!(ripples, vec![(960.0, 540.0, 0.0)]);
+    }
+
+    #[test]
+    fn negative_monitor_origin_translates_before_hidpi_scaling() {
+        let mut sidecar = PointerSidecar::new(
+            0,
+            CaptureRegion {
+                x: -1280,
+                y: -200,
+                w: 1280,
+                h: 800,
+            },
+        );
+        sidecar.pointer.push(PointerSample {
+            t: 0.0,
+            x: -640.0,
+            y: 200.0,
+            kind: CursorKind::Default,
+        });
+        sidecar.clicks.push(ClickSample {
+            t: 0.0,
+            x: -640.0,
+            y: 200.0,
+            button: 1,
+        });
+
+        sidecar.subtract_region();
+        let frame = sidecar
+            .presented_in_video_at(0.0, CursorMotion::default(), 2560.0, 1600.0)
+            .unwrap();
+        assert_eq!((frame.x, frame.y), (1280.0, 800.0));
+        assert_eq!(
+            sidecar.click_ripples_in_video_at(0.0, 0.32, 2560.0, 1600.0),
+            vec![(1280.0, 800.0, 0.0)]
+        );
     }
 
     #[test]

--- a/src/recording/editor/zoom_suggest.rs
+++ b/src/recording/editor/zoom_suggest.rs
@@ -142,10 +142,37 @@ pub fn suggest_zooms(
         suggestions.truncate(limit);
     }
     suggestions.sort_by(|a, b| a.suggestion.start.total_cmp(&b.suggestion.start));
+    separate_overlapping_suggestions(&mut suggestions);
     suggestions
         .into_iter()
         .map(|scored| scored.suggestion)
         .collect()
+}
+
+/// Keep distinct interactions from causing one another to be discarded by
+/// the non-overlapping zoom track. Long click post-rolls commonly overlap the
+/// next click even though the clicks are far enough apart to form two
+/// sessions. Split that overlap only when both clips can remain useful.
+fn separate_overlapping_suggestions(suggestions: &mut [ScoredSuggestion]) {
+    for index in 1..suggestions.len() {
+        let (before, after) = suggestions.split_at_mut(index);
+        let previous = &mut before[index - 1].suggestion;
+        let next = &mut after[0].suggestion;
+        if previous.end <= next.start {
+            continue;
+        }
+
+        let earliest_boundary =
+            (previous.start + MIN_SUGGESTED_ZOOM_SECONDS).max(previous.center_time);
+        let latest_boundary = (next.end - MIN_SUGGESTED_ZOOM_SECONDS).min(next.center_time);
+        if earliest_boundary > latest_boundary {
+            continue;
+        }
+        let interaction_midpoint = (previous.center_time + next.center_time) * 0.5;
+        let boundary = interaction_midpoint.clamp(earliest_boundary, latest_boundary);
+        previous.end = boundary;
+        next.start = boundary;
+    }
 }
 
 fn pointer_scale(sidecar: &PointerSidecar, width: f64, height: f64) -> Option<(f64, f64)> {
@@ -669,6 +696,21 @@ mod tests {
         assert!(suggestions[0].end <= suggestions[1].end);
         assert_eq!(suggestions[0].scale, AUTO_ZOOM_SCALE);
         assert_eq!(suggestions[1].scale, AUTO_ZOOM_SCALE);
+    }
+
+    #[test]
+    fn adjacent_click_sessions_keep_non_overlapping_suggestions() {
+        let mut data = sidecar();
+        data.clicks
+            .extend([click(3.0, 400.0, 300.0), click(4.3, 1_500.0, 700.0)]);
+
+        let suggestions = suggest_zooms(&data, W, H, 10.0);
+
+        assert_eq!(suggestions.len(), 2);
+        assert!(suggestions[0].end <= suggestions[1].start);
+        assert!(suggestions
+            .iter()
+            .all(|suggestion| suggestion.end - suggestion.start >= MIN_SUGGESTED_ZOOM_SECONDS));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Resolve fullscreen pointer bounds from GNOME Shell monitor geometry, not overlay/work-area bounds. Preserve the exact selected region for area captures, including negative monitor origins and HiDPI scaling.
- Add a backward-compatible GetMonitorGeometryAt D-Bus method and run the new lookup off the async worker. Older extensions retain legacy behavior with an explicit log.
- Split overlapping Detect suggestions so adjacent distinct click sessions are not unnecessarily discarded.
- Refit detections near trims and assign cut-boundary clicks consistently with source-time lookup, including floating-point tolerance.

## Validation
- 167 recording-editor unit tests passed.
- 13 recording-control unit tests passed.
- cargo fmt --all -- --check; cargo check --locked; JavaScript module syntax check; git diff --check passed.
- cargo clippy completed using the documented local toolchain workaround, with warnings.

## Desktop validation limitations
This environment has no live GNOME/Wayland desktop. Install the updated extension to use the new monitor lookup. Verify area/fullscreen recordings on HiDPI and monitors left/above the primary screen. The portal may allow choosing a different monitor than requested; this patch does not establish a stable identity for such a different portal-selected monitor and does not claim that case is solved. Legacy extension fallback remains unchanged.

## Scope
Seven source/test files only, based directly on current GitHub main. No Replit configuration, local build overrides, or earlier local-only commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/apex-shot/codesmith/apexshot/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791311781&installation_model_id=20563&pr_number=51&repository=apex-shot%2Fapexshot&return_to=https%3A%2F%2Fgithub.com%2Fapex-shot%2Fapexshot%2Fpull%2F51&signature=af39fdc3d3b0002ac799d3d9bc05ca3622a5554df9aa86ac9f52515050b1f462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->